### PR TITLE
Add GPU acceleration support (DirectML and CUDA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A .NET library for text-to-speech synthesis using Microsoft's [VibeVoice-Realtim
 - 🔊 **Natural Text-to-Speech** — High-quality speech synthesis powered by VibeVoice-Realtime-0.5B
 - 📦 **NuGet Package** — [`ElBruno.VibeVoiceTTS`](https://www.nuget.org/packages/ElBruno.VibeVoiceTTS) — install and start generating speech in minutes
 - 🤖 **Pure C# Inference** — ONNX Runtime, zero Python dependency at runtime
+- 🚀 **GPU Acceleration** — DirectML (any Windows GPU) and CUDA (NVIDIA) support with automatic CPU fallback
 - 📥 **Auto-Download** — Models automatically downloaded from 🤗 HuggingFace on first use
 - 🌍 **6 Voice Presets** — Carter, Davis, Emma, Frank, Grace, Mike (English voices with multilingual experimental support)
 - 💉 **Dependency Injection** — First-class `IServiceCollection` integration
@@ -83,10 +84,44 @@ using var tts = new VibeVoiceSynthesizer(options);
 | `CfgScale` | `1.5` | Classifier-free guidance scale |
 | `SampleRate` | `24000` | Output audio sample rate (Hz) |
 | `Seed` | `42` | Random seed for reproducible output |
+| `ExecutionProvider` | `Cpu` | ONNX Runtime execution provider (`Cpu`, `DirectML`, `Cuda`) |
+| `GpuDeviceId` | `0` | GPU device index (used with DirectML or CUDA) |
 
 *\*Default model cache: Windows: `%LOCALAPPDATA%\ElBruno\VibeVoice\models` · Linux/macOS: `~/.local/share/elbruno/vibevoice/models`*
 
-### 5) Dependency Injection
+### 5) GPU Acceleration
+
+Enable GPU acceleration by setting the execution provider and installing the corresponding NuGet package:
+
+```bash
+# For DirectML (any Windows GPU — NVIDIA, AMD, Intel):
+dotnet add package Microsoft.ML.OnnxRuntime.DirectML
+
+# For CUDA (NVIDIA only — Windows and Linux):
+dotnet add package Microsoft.ML.OnnxRuntime.Gpu
+```
+
+```csharp
+// DirectML — recommended for Windows desktop apps
+var options = new VibeVoiceOptions
+{
+    ExecutionProvider = ExecutionProvider.DirectML,
+    GpuDeviceId = 0   // optional, selects which GPU
+};
+using var tts = new VibeVoiceSynthesizer(options);
+
+// CUDA — for NVIDIA GPUs with CUDA drivers
+var options = new VibeVoiceOptions
+{
+    ExecutionProvider = ExecutionProvider.Cuda,
+    GpuDeviceId = 0
+};
+using var tts = new VibeVoiceSynthesizer(options);
+```
+
+> **💡 Note:** If the selected GPU provider is unavailable (missing NuGet package or no compatible GPU), the library automatically falls back to CPU inference.
+
+### 6) Dependency Injection
 
 ```csharp
 builder.Services.AddVibeVoice(options =>

--- a/src/ElBruno.VibeVoiceTTS.Tests/ExecutionProviderTests.cs
+++ b/src/ElBruno.VibeVoiceTTS.Tests/ExecutionProviderTests.cs
@@ -1,0 +1,89 @@
+using ElBruno.VibeVoiceTTS;
+using ElBruno.VibeVoiceTTS.Pipeline;
+using Microsoft.ML.OnnxRuntime;
+
+namespace ElBruno.VibeVoiceTTS.Tests;
+
+public class ExecutionProviderTests
+{
+    [Fact]
+    public void Default_ExecutionProvider_IsCpu()
+    {
+        var opts = new VibeVoiceOptions();
+        Assert.Equal(ExecutionProvider.Cpu, opts.ExecutionProvider);
+    }
+
+    [Fact]
+    public void Default_GpuDeviceId_IsZero()
+    {
+        var opts = new VibeVoiceOptions();
+        Assert.Equal(0, opts.GpuDeviceId);
+    }
+
+    [Fact]
+    public void GpuDeviceId_AcceptsZero()
+    {
+        var opts = new VibeVoiceOptions { GpuDeviceId = 0 };
+        Assert.Equal(0, opts.GpuDeviceId);
+    }
+
+    [Fact]
+    public void GpuDeviceId_AcceptsPositive()
+    {
+        var opts = new VibeVoiceOptions { GpuDeviceId = 3 };
+        Assert.Equal(3, opts.GpuDeviceId);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void GpuDeviceId_RejectsNegative(int value)
+    {
+        var opts = new VibeVoiceOptions();
+        Assert.Throws<ArgumentOutOfRangeException>(() => opts.GpuDeviceId = value);
+    }
+
+    [Fact]
+    public void ExecutionProvider_CanSetDirectML()
+    {
+        var opts = new VibeVoiceOptions { ExecutionProvider = ExecutionProvider.DirectML };
+        Assert.Equal(ExecutionProvider.DirectML, opts.ExecutionProvider);
+    }
+
+    [Fact]
+    public void ExecutionProvider_CanSetCuda()
+    {
+        var opts = new VibeVoiceOptions { ExecutionProvider = ExecutionProvider.Cuda };
+        Assert.Equal(ExecutionProvider.Cuda, opts.ExecutionProvider);
+    }
+
+    [Fact]
+    public void ConfigureExecutionProvider_Cpu_DoesNotThrow()
+    {
+        using var sessionOptions = new SessionOptions();
+        // Should be a no-op for CPU
+        OnnxInferencePipeline.ConfigureExecutionProvider(sessionOptions, ExecutionProvider.Cpu, 0);
+    }
+
+    [Fact]
+    public void ConfigureExecutionProvider_DirectML_FallsBackGracefully()
+    {
+        // On a machine without Microsoft.ML.OnnxRuntime.DirectML, this should not throw
+        using var sessionOptions = new SessionOptions();
+        var ex = Record.Exception(() =>
+            OnnxInferencePipeline.ConfigureExecutionProvider(sessionOptions, ExecutionProvider.DirectML, 0));
+        // Either succeeds (GPU available) or silently falls back (no throw)
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void ConfigureExecutionProvider_Cuda_FallsBackGracefully()
+    {
+        // On a machine without Microsoft.ML.OnnxRuntime.Gpu, this should not throw
+        using var sessionOptions = new SessionOptions();
+        var ex = Record.Exception(() =>
+            OnnxInferencePipeline.ConfigureExecutionProvider(sessionOptions, ExecutionProvider.Cuda, 0));
+        // Either succeeds (CUDA available) or silently falls back (no throw)
+        Assert.Null(ex);
+    }
+}

--- a/src/ElBruno.VibeVoiceTTS/ExecutionProvider.cs
+++ b/src/ElBruno.VibeVoiceTTS/ExecutionProvider.cs
@@ -1,0 +1,24 @@
+namespace ElBruno.VibeVoiceTTS;
+
+/// <summary>
+/// Specifies the ONNX Runtime execution provider for model inference.
+/// </summary>
+public enum ExecutionProvider
+{
+    /// <summary>
+    /// CPU execution (default). Uses the built-in Microsoft.ML.OnnxRuntime package.
+    /// </summary>
+    Cpu = 0,
+
+    /// <summary>
+    /// DirectML GPU acceleration (NVIDIA, AMD, Intel — Windows only).
+    /// Requires the Microsoft.ML.OnnxRuntime.DirectML NuGet package.
+    /// </summary>
+    DirectML = 1,
+
+    /// <summary>
+    /// CUDA GPU acceleration (NVIDIA only — Windows and Linux).
+    /// Requires the Microsoft.ML.OnnxRuntime.Gpu NuGet package.
+    /// </summary>
+    Cuda = 2
+}

--- a/src/ElBruno.VibeVoiceTTS/VibeVoiceOptions.cs
+++ b/src/ElBruno.VibeVoiceTTS/VibeVoiceOptions.cs
@@ -77,6 +77,31 @@ public sealed class VibeVoiceOptions
     public int Seed { get; set; } = 42;
 
     /// <summary>
+    /// Execution provider for ONNX Runtime inference (default: Cpu).
+    /// Set to DirectML for Windows GPU acceleration (any vendor), or Cuda for NVIDIA GPUs.
+    /// The consumer must install the corresponding NuGet package:
+    /// - DirectML: Microsoft.ML.OnnxRuntime.DirectML
+    /// - Cuda: Microsoft.ML.OnnxRuntime.Gpu
+    /// </summary>
+    public ExecutionProvider ExecutionProvider { get; set; } = ExecutionProvider.Cpu;
+
+    private int _gpuDeviceId;
+
+    /// <summary>
+    /// GPU device index when using DirectML or CUDA (default: 0).
+    /// Ignored when ExecutionProvider is Cpu.
+    /// </summary>
+    public int GpuDeviceId
+    {
+        get => _gpuDeviceId;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value, nameof(GpuDeviceId));
+            _gpuDeviceId = value;
+        }
+    }
+
+    /// <summary>
     /// Returns the effective model path, falling back to the OS-specific shared cache.
     /// </summary>
     public string GetEffectiveModelPath()

--- a/src/ElBruno.VibeVoiceTTS/VibeVoiceSynthesizer.cs
+++ b/src/ElBruno.VibeVoiceTTS/VibeVoiceSynthesizer.cs
@@ -118,7 +118,9 @@ public sealed class VibeVoiceSynthesizer : IVibeVoiceSynthesizer
                 ModelPath,
                 _options.DiffusionSteps,
                 _options.CfgScale,
-                _options.Seed);
+                _options.Seed,
+                _options.ExecutionProvider,
+                _options.GpuDeviceId);
 
             return _pipeline;
         }

--- a/src/scenario-03-csharp-simple/Program.cs
+++ b/src/scenario-03-csharp-simple/Program.cs
@@ -14,6 +14,10 @@ var options = new VibeVoiceOptions();
 // To use a custom model path instead of the default cache:
 // options.ModelPath = @"C:\path\to\models";
 
+// To enable GPU acceleration (requires Microsoft.ML.OnnxRuntime.DirectML NuGet):
+// options.ExecutionProvider = ExecutionProvider.DirectML;
+// options.GpuDeviceId = 0;
+
 using var tts = new VibeVoiceSynthesizer(options);
 
 Console.WriteLine($"📦 Model path: {tts.ModelPath}");


### PR DESCRIPTION
- Add ExecutionProvider enum (Cpu, DirectML, Cuda)
- Add ExecutionProvider and GpuDeviceId properties to VibeVoiceOptions
- Update OnnxInferencePipeline to configure SessionOptions with selected provider
- Automatic CPU fallback when GPU provider unavailable
- Add 11 new tests for GPU options and fallback behavior (79 total)
- Update README with GPU section, options table, and NuGet instructions
- Update scenario-03 with commented GPU example