### PR TITLE
Fix #9: Upload all 6 voice presets to HuggingFace

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ builder.Services.AddVibeVoice(options =>
 | Grace | Female | `VibeVoicePreset.Grace` | `en-Grace_woman` |
 | Mike | Male | `VibeVoicePreset.Mike` | `en-Mike_man` |
 
+All 6 voice presets are available on [HuggingFace](https://huggingface.co/elbruno/VibeVoice-Realtime-0.5B-ONNX/tree/main/voices) and are downloaded on-demand when first used.
+
 > **⚡ Migration note:** In versions prior to 0.2.0, `GetAvailableVoices()` returned all 6 voices regardless of download status. Starting with 0.2.0, it returns only voices **actually downloaded on disk**. Use `GetSupportedVoices()` to see all 6 known presets. Voices are auto-downloaded on first use with `GenerateAudioAsync()`, or pre-download with `EnsureVoiceAvailableAsync("Davis")`.
 
 **Language support:** The model is primarily trained on **English**, with experimental multilingual capabilities (e.g., Spanish, French, German). Results may vary for non-English text.


### PR DESCRIPTION
## Problem
\GetAvailableVoices()\ listed 6 voices but only Carter and Emma had preset files on HuggingFace. Davis, Frank, Grace, and Mike failed with 404 on download.

## Fix
- Exported KV-cache .npy files for all 6 voices from Microsoft's VibeVoice .pt presets
- Uploaded Davis, Frank, Grace, Mike voice directories to \lbruno/VibeVoice-Realtime-0.5B-ONNX\ on HuggingFace
- Re-uploaded Carter and Emma for consistency (added missing \
egative/lm_hidden.npy\)
- Updated README to confirm all 6 voices available

## Verification
All 6 voice metadata.json files return HTTP 200 from HuggingFace.

No C# library code changes needed — on-demand download already handles all 6 voices.

Fixes #9