### PR TITLE
Document MaxTextLength option

### DIFF
--- a/.squad/agents/drummer/history.md
+++ b/.squad/agents/drummer/history.md
@@ -3,3 +3,11 @@
 ## Joined
 - **Date:** 2026-02-22
 - **Reason:** Added to manage GitHub issues and coordinate fixes across the team
+
+## Learnings
+
+### Issue #26 — Max text length documentation (2026-05-28)
+- **Files updated:** `src/ElBruno.VibeVoiceTTS/VibeVoiceOptions.cs`, `README.md`, `docs/GETTING_STARTED.md`
+- **Tests added:** `VibeVoiceOptionsTests` and `VibeVoiceSynthesizerTests` now cover the default `MaxTextLength` value and the disabled-path behavior.
+- **Release note:** Bumped package version to `0.5.1` for the documentation patch release.
+- **Key pattern:** Public option docs should be reflected in both XML comments and the package README because `README.md` is the NuGet package readme.

--- a/.squad/decisions/inbox/drummer-issue-26.md
+++ b/.squad/decisions/inbox/drummer-issue-26.md
@@ -1,0 +1,14 @@
+# Decision: Issue #26 — Document MaxTextLength
+
+## Summary
+Issue #26 is a documentation-focused patch for `VibeVoiceOptions.MaxTextLength`.
+
+## Decision
+- Document `MaxTextLength` in the public XML comments.
+- Surface the option in `README.md` because it is the NuGet package readme.
+- Add a short note in `docs/GETTING_STARTED.md` for the C# samples.
+- Add regression tests to lock in the default value and disabled behavior.
+
+## Release Impact
+- Package version bumped to `0.5.1`.
+

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ var options = new VibeVoiceOptions
     DiffusionSteps = 20,                 // Quality vs speed tradeoff
     CfgScale = 1.5f,                     // Classifier-free guidance scale
     SampleRate = 24000,                  // Output sample rate
+    MaxTextLength = 500,                 // Max characters per request (0 disables the limit)
 };
 
 using var tts = new VibeVoiceSynthesizer(options);
@@ -110,6 +111,7 @@ using var tts = new VibeVoiceSynthesizer(options);
 | `DiffusionSteps` | `20` | Number of diffusion denoising steps |
 | `CfgScale` | `1.5` | Classifier-free guidance scale |
 | `SampleRate` | `24000` | Output audio sample rate (Hz) |
+| `MaxTextLength` | `500` | Maximum characters accepted per request (`0` disables validation) |
 | `Seed` | `42` | Random seed for reproducible output |
 | `ExecutionProvider` | `Cpu` | ONNX Runtime execution provider (`Cpu`, `DirectML`, `Cuda`) |
 | `GpuDeviceId` | `0` | GPU device index (used with DirectML or CUDA) |
@@ -160,6 +162,7 @@ builder.Services.AddVibeVoice(options =>
 ```
 
 > **💡 Tip:** For best results, keep sentences short (~10 words). Longer text may produce artifacts due to model limitations. Consider splitting long text into sentences.
+> **💡 Tip:** The `MaxTextLength` option defaults to 500 characters. Raise it for long passages, or set it to `0` to disable the guard entirely.
 
 ## 🗣️ Voices & Languages
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -292,6 +292,8 @@ cd src/scenario-03-csharp-simple
 dotnet run
 ```
 
+To change the maximum prompt size in the C# samples, set `MaxTextLength` on `VibeVoiceOptions` (default: 500). Set it to `0` if you want to disable the guard.
+
 ### Expected Output
 
 ```

--- a/src/ElBruno.VibeVoiceTTS.Tests/VibeVoiceOptionsTests.cs
+++ b/src/ElBruno.VibeVoiceTTS.Tests/VibeVoiceOptionsTests.cs
@@ -13,7 +13,17 @@ public class VibeVoiceOptionsTests
         Assert.Equal(20, opts.DiffusionSteps);
         Assert.Equal(1.5f, opts.CfgScale);
         Assert.Equal(24000, opts.SampleRate);
+        Assert.Equal(500, opts.MaxTextLength);
         Assert.Equal(42, opts.Seed);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(int.MaxValue)]
+    public void MaxTextLength_AllowsDisabledValues(int value)
+    {
+        var opts = new VibeVoiceOptions { MaxTextLength = value };
+        Assert.Equal(value, opts.MaxTextLength);
     }
 
     [Fact]

--- a/src/ElBruno.VibeVoiceTTS.Tests/VibeVoiceSynthesizerTests.cs
+++ b/src/ElBruno.VibeVoiceTTS.Tests/VibeVoiceSynthesizerTests.cs
@@ -178,6 +178,30 @@ public class VibeVoiceSynthesizerTests
     }
 
     [Fact]
+    public void ValidateTextLength_UsesConfiguredLimit()
+    {
+        using var tts = new VibeVoiceSynthesizer(new VibeVoiceOptions
+        {
+            MaxTextLength = 10
+        });
+
+        tts.ValidateTextLength("short text");
+        var ex = Assert.Throws<ArgumentException>(() => tts.ValidateTextLength("this text is too long"));
+        Assert.Contains("maximum length of 10", ex.Message);
+    }
+
+    [Fact]
+    public void ValidateTextLength_AllowsDisabledLimit()
+    {
+        using var tts = new VibeVoiceSynthesizer(new VibeVoiceOptions
+        {
+            MaxTextLength = 0
+        });
+
+        tts.ValidateTextLength(new string('a', 5000));
+    }
+
+    [Fact]
     public void GetVoiceFiles_ReturnsExpectedFileCount()
     {
         var files = ModelManager.GetVoiceFiles("en-Carter_man");

--- a/src/ElBruno.VibeVoiceTTS/ElBruno.VibeVoiceTTS.csproj
+++ b/src/ElBruno.VibeVoiceTTS/ElBruno.VibeVoiceTTS.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>ElBruno.VibeVoiceTTS</PackageId>
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
     <Authors>Bruno Capuano</Authors>
     <Description>A .NET library for VibeVoice text-to-speech using ONNX Runtime. Supports automatic model download from HuggingFace, voice presets, and native C# inference with no Python dependency.</Description>
     <PackageTags>tts;text-to-speech;vibevoice;onnx;onnxruntime;speech;audio;ai;ml</PackageTags>

--- a/src/ElBruno.VibeVoiceTTS/VibeVoiceOptions.cs
+++ b/src/ElBruno.VibeVoiceTTS/VibeVoiceOptions.cs
@@ -85,7 +85,8 @@ public sealed class VibeVoiceOptions
     }
     
     /// <summary>
-    /// Max Text length for speech sythesis.(default: 500), set it to 0 or Int32.MaxValue
+    /// Maximum text length for speech synthesis (default: 500).
+    /// Set to 0 or <see cref="int.MaxValue"/> to disable length validation.
     /// </summary>
     public int MaxTextLength { get; set; } = 500;
 

--- a/src/ElBruno.VibeVoiceTTS/VibeVoiceSynthesizer.cs
+++ b/src/ElBruno.VibeVoiceTTS/VibeVoiceSynthesizer.cs
@@ -203,10 +203,9 @@ public sealed class VibeVoiceSynthesizer : IVibeVoiceSynthesizer
     }
 
     /// <summary>
-    /// Validates that text input is within safe length limits.
-    /// Maximum 500 characters to prevent resource exhaustion.
+    /// Validates that text input is within the configured length limit.
     /// </summary>
-    /// <exception cref="ArgumentException">Thrown when text exceeds 500 characters.</exception>
+    /// <exception cref="ArgumentException">Thrown when text exceeds the configured length limit.</exception>
     internal void ValidateTextLength(string text)
     {
         if (_options.MaxTextLength == 0 || text.Length <= _options.MaxTextLength)


### PR DESCRIPTION
Closes #26\n\nSummary:\n- Document MaxTextLength in the public XML comments and package README\n- Add a brief note in the getting-started guide\n- Add regression tests for default and disabled behavior\n- Bump package version to 0.5.1