### PR TITLE
Add cancellable generation checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,26 @@ builder.Services.AddVibeVoice(options =>
 // Then inject IVibeVoiceSynthesizer in your services
 ```
 
+### 8) Cancellation, metrics, and concurrent use
+
+```csharp
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+tts.GenerationMetricReported += (_, metric) =>
+{
+    Console.WriteLine($"{metric.Stage}: {metric.Elapsed.TotalMilliseconds:F0} ms ({metric.FramesGenerated} frames)");
+};
+
+float[] audio = await tts.GenerateAudioAsync(
+    "This request can be cancelled while queued or during generation.",
+    "Carter",
+    cts.Token);
+```
+
+> **💡 Concurrency behavior:** A single `VibeVoiceSynthesizer` instance serializes `GenerateAudioAsync()` and `EnsureVoiceAvailableAsync()` calls so the shared ONNX pipeline cannot be mutated mid-request. If a caller is waiting for that capacity, cancelling its `CancellationToken` aborts the wait. Create multiple synthesizer instances if you need true parallel generation.
+>
+> **💡 Metrics behavior:** `GenerationMetricReported` emits `FirstAudioReady` when the first latent audio frame is ready and `Completed` when the final waveform has been decoded.
+
 > **💡 Tip:** For best results, keep sentences short (~10 words). Longer text may produce artifacts due to model limitations. Consider splitting long text into sentences.
 > **💡 Tip:** The `MaxTextLength` option defaults to 500 characters. Raise it for long passages, or set it to `0` to disable the guard entirely.
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,6 +2,8 @@
 
 This guide walks you through setting up and running VibeVoiceTTS.
 
+> **C# library runtime behavior:** Each `VibeVoiceSynthesizer` instance processes one generation request at a time so its shared ONNX pipeline stays consistent. Pass a `CancellationToken` to cancel queued or in-flight generation, and subscribe to `GenerationMetricReported` if you want first-audio and total-duration timings.
+
 ## Prerequisites
 
 ### Required Software

--- a/src/ElBruno.VibeVoiceTTS.Tests/VibeVoiceSynthesizerTests.cs
+++ b/src/ElBruno.VibeVoiceTTS.Tests/VibeVoiceSynthesizerTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+using ElBruno.VibeVoiceTTS.Pipeline;
 using ElBruno.VibeVoiceTTS;
 
 namespace ElBruno.VibeVoiceTTS.Tests;
@@ -269,5 +271,173 @@ public class VibeVoiceSynthesizerTests
         Assert.NotEmpty(reports);
         Assert.Equal(DownloadStage.Complete, reports.Last().Stage);
         Assert.Equal(100, reports.Last().PercentComplete);
+    }
+
+    [Fact]
+    public async Task GenerateAudioAsync_WhenBusy_WaitingRequestCanBeCancelled()
+    {
+        var firstStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirst = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var tts = CreateTestSynthesizer(new BlockingPipeline(firstStarted, releaseFirst));
+
+        Task<float[]> first = tts.GenerateAudioAsync("first", "Carter");
+        await firstStarted.Task;
+
+        using var cts = new CancellationTokenSource();
+        Task<float[]> second = tts.GenerateAudioAsync("second", "Emma", cts.Token);
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => second);
+
+        releaseFirst.SetResult();
+        await first;
+    }
+
+    [Fact]
+    public async Task GenerateAudioAsync_ReportsFirstAudioAndCompletionMetrics()
+    {
+        using var tts = CreateTestSynthesizer(new MetricsPipeline());
+        var reports = new List<GenerationMetric>();
+        tts.GenerationMetricReported += (_, metric) => reports.Add(metric);
+
+        float[] audio = await tts.GenerateAudioAsync("hello", "Carter");
+
+        Assert.Single(audio);
+        Assert.Equal(2, reports.Count);
+        Assert.Equal(GenerationMetricStage.FirstAudioReady, reports[0].Stage);
+        Assert.Equal(GenerationMetricStage.Completed, reports[1].Stage);
+        Assert.Equal("en-Carter_man", reports[0].VoiceName);
+        Assert.Equal("en-Carter_man", reports[1].VoiceName);
+        Assert.Equal(1, reports[0].FramesGenerated);
+        Assert.Equal(2, reports[1].FramesGenerated);
+        Assert.True(reports[1].Elapsed >= reports[0].Elapsed);
+    }
+
+    [Fact]
+    public async Task GenerateAudioAsync_StressSwitchesVoicesWithoutCrossRequestLeakage()
+    {
+        var pipeline = new TrackingPipeline();
+        using var tts = CreateTestSynthesizer(pipeline);
+        string[] voices = ["Carter", "Emma", "Davis", "Grace"];
+
+        Task<float[]>[] tasks = Enumerable.Range(0, 32)
+            .Select(i => tts.GenerateAudioAsync($"text-{i}", voices[i % voices.Length]))
+            .ToArray();
+
+        float[][] results = await Task.WhenAll(tasks);
+
+        Assert.Equal(1, pipeline.MaxConcurrency);
+        Assert.Equal(32, pipeline.Requests.Count);
+
+        for (int i = 0; i < results.Length; i++)
+        {
+            string expectedVoice = VibeVoiceSynthesizer.ResolveVoiceName(voices[i % voices.Length]);
+            Assert.Single(results[i]);
+            Assert.Equal(TrackingPipeline.GetVoiceMarker(expectedVoice), (int)results[i][0]);
+        }
+    }
+
+    private static VibeVoiceSynthesizer CreateTestSynthesizer(IGenerationPipeline pipeline)
+    {
+        return new VibeVoiceSynthesizer(
+            new VibeVoiceOptions { ModelPath = VibeVoiceOptions.GetDefaultModelPath() },
+            new VibeVoiceRuntimeDependencies
+            {
+                IsModelAvailable = static _ => true,
+                IsVoiceAvailable = static (_, _) => true,
+                EnsureModelAvailableAsync = static (_, _, _, _) => Task.CompletedTask,
+                EnsureVoiceAvailableAsync = static (_, _, _, _, _) => Task.CompletedTask,
+                CreatePipeline = (_, _) => pipeline
+            });
+    }
+
+    private sealed class BlockingPipeline(TaskCompletionSource firstStarted, TaskCompletionSource releaseFirst) : IGenerationPipeline
+    {
+        private int _callCount;
+
+        public float[] GenerateAudio(string text, string voice, CancellationToken cancellationToken, Action<GenerationMetric>? reportMetric = null)
+        {
+            if (Interlocked.Increment(ref _callCount) == 1)
+            {
+                firstStarted.SetResult();
+                releaseFirst.Task.GetAwaiter().GetResult();
+            }
+
+            return [1f];
+        }
+
+        public string[] GetAvailableVoices() => ["en-Carter_man", "en-Emma_woman"];
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class MetricsPipeline : IGenerationPipeline
+    {
+        public float[] GenerateAudio(string text, string voice, CancellationToken cancellationToken, Action<GenerationMetric>? reportMetric = null)
+        {
+            reportMetric?.Invoke(new GenerationMetric
+            {
+                Stage = GenerationMetricStage.FirstAudioReady,
+                VoiceName = voice,
+                Elapsed = TimeSpan.FromMilliseconds(15),
+                FramesGenerated = 1
+            });
+            reportMetric?.Invoke(new GenerationMetric
+            {
+                Stage = GenerationMetricStage.Completed,
+                VoiceName = voice,
+                Elapsed = TimeSpan.FromMilliseconds(40),
+                FramesGenerated = 2
+            });
+            return [1f];
+        }
+
+        public string[] GetAvailableVoices() => ["en-Carter_man"];
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class TrackingPipeline : IGenerationPipeline
+    {
+        private static readonly IReadOnlyDictionary<string, int> VoiceMarkers = new Dictionary<string, int>
+        {
+            ["en-Carter_man"] = 101,
+            ["en-Davis_man"] = 102,
+            ["en-Emma_woman"] = 103,
+            ["en-Grace_woman"] = 104
+        };
+
+        private int _currentConcurrency;
+        public int MaxConcurrency { get; private set; }
+        public ConcurrentQueue<string> Requests { get; } = new();
+
+        public static int GetVoiceMarker(string voice) => VoiceMarkers[voice];
+
+        public float[] GenerateAudio(string text, string voice, CancellationToken cancellationToken, Action<GenerationMetric>? reportMetric = null)
+        {
+            int current = Interlocked.Increment(ref _currentConcurrency);
+            MaxConcurrency = Math.Max(MaxConcurrency, current);
+            Requests.Enqueue(voice);
+
+            try
+            {
+                Thread.Sleep(10);
+                return [GetVoiceMarker(voice)];
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _currentConcurrency);
+            }
+        }
+
+        public string[] GetAvailableVoices() => ["en-Carter_man", "en-Davis_man", "en-Emma_woman", "en-Grace_woman"];
+
+        public void Dispose()
+        {
+        }
     }
 }

--- a/src/ElBruno.VibeVoiceTTS/ElBruno.VibeVoiceTTS.csproj
+++ b/src/ElBruno.VibeVoiceTTS/ElBruno.VibeVoiceTTS.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>ElBruno.VibeVoiceTTS</PackageId>
-    <Version>0.5.1</Version>
+    <Version>0.5.2</Version>
     <Authors>Bruno Capuano</Authors>
     <Description>A .NET library for VibeVoice text-to-speech using ONNX Runtime. Supports automatic model download from HuggingFace, voice presets, and native C# inference with no Python dependency.</Description>
     <PackageTags>tts;text-to-speech;vibevoice;onnx;onnxruntime;speech;audio;ai;ml</PackageTags>

--- a/src/ElBruno.VibeVoiceTTS/GenerationMetric.cs
+++ b/src/ElBruno.VibeVoiceTTS/GenerationMetric.cs
@@ -1,0 +1,27 @@
+namespace ElBruno.VibeVoiceTTS;
+
+/// <summary>
+/// Timing metric emitted during speech generation.
+/// </summary>
+public sealed class GenerationMetric
+{
+    /// <summary>
+    /// Which generation checkpoint emitted this metric.
+    /// </summary>
+    public required GenerationMetricStage Stage { get; init; }
+
+    /// <summary>
+    /// Internal voice name used for generation (for example, "en-Carter_man").
+    /// </summary>
+    public required string VoiceName { get; init; }
+
+    /// <summary>
+    /// Elapsed time since generation started.
+    /// </summary>
+    public required TimeSpan Elapsed { get; init; }
+
+    /// <summary>
+    /// Number of latent frames generated when the metric was emitted.
+    /// </summary>
+    public required int FramesGenerated { get; init; }
+}

--- a/src/ElBruno.VibeVoiceTTS/GenerationMetricStage.cs
+++ b/src/ElBruno.VibeVoiceTTS/GenerationMetricStage.cs
@@ -1,0 +1,17 @@
+namespace ElBruno.VibeVoiceTTS;
+
+/// <summary>
+/// Generation timing checkpoints reported by the synthesizer.
+/// </summary>
+public enum GenerationMetricStage
+{
+    /// <summary>
+    /// The first latent audio frame has been generated.
+    /// </summary>
+    FirstAudioReady,
+
+    /// <summary>
+    /// Full audio generation has completed.
+    /// </summary>
+    Completed
+}

--- a/src/ElBruno.VibeVoiceTTS/IVibeVoiceSynthesizer.cs
+++ b/src/ElBruno.VibeVoiceTTS/IVibeVoiceSynthesizer.cs
@@ -6,6 +6,11 @@ namespace ElBruno.VibeVoiceTTS;
 public interface IVibeVoiceSynthesizer : IDisposable
 {
     /// <summary>
+    /// Raised when generation reaches the first-audio and completion checkpoints.
+    /// </summary>
+    event EventHandler<GenerationMetric>? GenerationMetricReported;
+
+    /// <summary>
     /// Gets whether all required ONNX model files are present at the configured model path.
     /// </summary>
     bool IsModelAvailable { get; }
@@ -24,6 +29,8 @@ public interface IVibeVoiceSynthesizer : IDisposable
 
     /// <summary>
     /// Generates audio samples from text using the specified voice preset.
+    /// A single synthesizer instance serializes generation requests to protect the shared ONNX pipeline.
+    /// If the synthesizer is already busy, waiting for capacity honors the supplied cancellation token.
     /// </summary>
     /// <returns>Float array of audio samples at 24kHz, normalized to [-1, 1].</returns>
     Task<float[]> GenerateAudioAsync(
@@ -33,6 +40,8 @@ public interface IVibeVoiceSynthesizer : IDisposable
 
     /// <summary>
     /// Generates audio samples from text using a voice name string.
+    /// A single synthesizer instance serializes generation requests to protect the shared ONNX pipeline.
+    /// If the synthesizer is already busy, waiting for capacity honors the supplied cancellation token.
     /// </summary>
     Task<float[]> GenerateAudioAsync(
         string text,
@@ -70,6 +79,7 @@ public interface IVibeVoiceSynthesizer : IDisposable
     /// <summary>
     /// Downloads a specific voice preset if not already available.
     /// Accepts both short names ("Davis") and internal names ("en-Davis_man").
+    /// This operation is serialized with generation so the shared pipeline cannot be reloaded mid-request.
     /// </summary>
     Task EnsureVoiceAvailableAsync(
         string voiceName,

--- a/src/ElBruno.VibeVoiceTTS/Pipeline/IGenerationPipeline.cs
+++ b/src/ElBruno.VibeVoiceTTS/Pipeline/IGenerationPipeline.cs
@@ -1,0 +1,12 @@
+namespace ElBruno.VibeVoiceTTS.Pipeline;
+
+internal interface IGenerationPipeline : IDisposable
+{
+    float[] GenerateAudio(
+        string text,
+        string voice,
+        CancellationToken cancellationToken,
+        Action<GenerationMetric>? reportMetric = null);
+
+    string[] GetAvailableVoices();
+}

--- a/src/ElBruno.VibeVoiceTTS/Pipeline/OnnxInferencePipeline.cs
+++ b/src/ElBruno.VibeVoiceTTS/Pipeline/OnnxInferencePipeline.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
 
@@ -9,7 +10,7 @@ namespace ElBruno.VibeVoiceTTS.Pipeline;
 ///       autoregressive loop: diffusion → acoustic_connector → TTS-LM step → EOS check →
 ///       batch acoustic decode → audio
 /// </summary>
-internal sealed class OnnxInferencePipeline : IDisposable
+internal sealed class OnnxInferencePipeline : IGenerationPipeline
 {
     private readonly InferenceSession _lmWithKv;
     private readonly InferenceSession _ttsLmPrefill;
@@ -106,10 +107,16 @@ internal sealed class OnnxInferencePipeline : IDisposable
         }
     }
 
-    public float[] GenerateAudio(string text, string voice)
+    public float[] GenerateAudio(
+        string text,
+        string voice,
+        CancellationToken cancellationToken,
+        Action<GenerationMetric>? reportMetric = null)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentException.ThrowIfNullOrWhiteSpace(text);
+        cancellationToken.ThrowIfCancellationRequested();
+        var stopwatch = Stopwatch.StartNew();
 
         // Load voice preset KV-cache
         var preset = _voicePresets.GetVoicePreset(voice);
@@ -119,9 +126,10 @@ internal sealed class OnnxInferencePipeline : IDisposable
         // Tokenize
         int[] tokenIds = _tokenizer.Encode(text);
         int textLen = tokenIds.Length;
+        cancellationToken.ThrowIfCancellationRequested();
 
         // Step 1: Language model with KV-cache
-        float[] lmHidden = RunLmWithKv(tokenIds, preset, lmPromptLen);
+        float[] lmHidden = RunLmWithKv(tokenIds, preset, lmPromptLen, cancellationToken);
 
         // Step 2: Add text type embedding and run TTS-LM prefill
         float[] textTypeEmbed = GetTypeEmbedding(1); // text = type 1
@@ -132,14 +140,16 @@ internal sealed class OnnxInferencePipeline : IDisposable
         var (posHidden, posKeys, posValues) = RunTtsLmPrefill(
             ttsInput, textLen, ttsPromptLen,
             StackKvArrays(preset, "tts_kv_key_", NumTtsLayers),
-            StackKvArrays(preset, "tts_kv_value_", NumTtsLayers));
+            StackKvArrays(preset, "tts_kv_value_", NumTtsLayers),
+            cancellationToken);
 
         // Negative path: prefill with negative voice preset KV-cache
         int negPromptLen = GetKvSeqLen(preset, "neg_tts_kv_key_0");
         var (negHidden, negKeys, negValues) = RunTtsLmPrefill(
             ttsInput, textLen, negPromptLen,
             StackKvArrays(preset, "neg_tts_kv_key_", NumTtsLayers),
-            StackKvArrays(preset, "neg_tts_kv_value_", NumTtsLayers));
+            StackKvArrays(preset, "neg_tts_kv_value_", NumTtsLayers),
+            cancellationToken);
 
         // Step 3: Autoregressive speech generation
         var allLatents = new List<float[]>();
@@ -148,6 +158,8 @@ internal sealed class OnnxInferencePipeline : IDisposable
 
         for (int frame = 0; frame < MaxFrames; frame++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             // Extract condition from last hidden state
             float[] posCond = ExtractLastHidden(posHidden, textLen > 0 && frame == 0 ? textLen : 1);
             float[] negCond = ExtractLastHidden(negHidden, textLen > 0 && frame == 0 ? textLen : 1);
@@ -155,16 +167,27 @@ internal sealed class OnnxInferencePipeline : IDisposable
             // EOS check (skip frame 0)
             if (frame > 0)
             {
-                float eosProb = RunEosClassifier(posCond);
+                float eosProb = RunEosClassifier(posCond, cancellationToken);
                 if (eosProb > 0.5f) break;
             }
 
             // Diffusion with CFG
-            float[] latent = RunDiffusion(posCond, negCond, frame);
+            float[] latent = RunDiffusion(posCond, negCond, frame, cancellationToken);
             allLatents.Add(latent);
 
+            if (allLatents.Count == 1)
+            {
+                reportMetric?.Invoke(new GenerationMetric
+                {
+                    Stage = GenerationMetricStage.FirstAudioReady,
+                    VoiceName = voice,
+                    Elapsed = stopwatch.Elapsed,
+                    FramesGenerated = allLatents.Count
+                });
+            }
+
             // Feedback: acoustic_connector → type embedding → TTS-LM step
-            float[] acEmbed = RunAcousticConnector(latent);
+            float[] acEmbed = RunAcousticConnector(latent, cancellationToken);
             float[] speechEmbed = new float[HiddenSize];
             for (int i = 0; i < HiddenSize; i++)
                 speechEmbed[i] = acEmbed[i] + speechTypeEmbed[i];
@@ -172,25 +195,39 @@ internal sealed class OnnxInferencePipeline : IDisposable
             // Update positive path
             posTotalLen++;
             (posHidden, posKeys, posValues) = RunTtsLmStep(
-                speechEmbed, posTotalLen, posKeys, posValues);
+                speechEmbed, posTotalLen, posKeys, posValues, cancellationToken);
 
             // Update negative path
             negTotalLen++;
             (negHidden, negKeys, negValues) = RunTtsLmStep(
-                speechEmbed, negTotalLen, negKeys, negValues);
+                speechEmbed, negTotalLen, negKeys, negValues, cancellationToken);
 
             // After first frame, textLen is consumed
             textLen = 0;
         }
 
         // Decode all latents
-        return DecodeLatents(allLatents);
+        cancellationToken.ThrowIfCancellationRequested();
+        float[] audio = DecodeLatents(allLatents, cancellationToken);
+        reportMetric?.Invoke(new GenerationMetric
+        {
+            Stage = GenerationMetricStage.Completed,
+            VoiceName = voice,
+            Elapsed = stopwatch.Elapsed,
+            FramesGenerated = allLatents.Count
+        });
+        return audio;
     }
 
     public string[] GetAvailableVoices() => _voicePresets.GetAvailableVoices();
 
-    private float[] RunLmWithKv(int[] tokenIds, Dictionary<string, float[]> preset, int lmPromptLen)
+    private float[] RunLmWithKv(
+        int[] tokenIds,
+        Dictionary<string, float[]> preset,
+        int lmPromptLen,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         int textLen = tokenIds.Length;
         int totalLen = lmPromptLen + textLen;
 
@@ -215,15 +252,19 @@ internal sealed class OnnxInferencePipeline : IDisposable
                 CreateKvTensor(pastValues, NumLmLayers, lmPromptLen)),
         };
 
+        cancellationToken.ThrowIfCancellationRequested();
         using var results = _lmWithKv.Run(inputs);
         var resultList = results.ToList();
+        cancellationToken.ThrowIfCancellationRequested();
         return resultList[0].AsTensor<float>().ToArray(); // [1, textLen, 896]
     }
 
     private (float[] hidden, float[] keys, float[] values) RunTtsLmPrefill(
         float[] inputEmbeds, int seqLen, int promptLen,
-        float[] pastKeys, float[] pastValues)
+        float[] pastKeys, float[] pastValues,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         int totalLen = promptLen + seqLen;
         var mask = new long[totalLen];
         Array.Fill(mask, 1L);
@@ -245,8 +286,10 @@ internal sealed class OnnxInferencePipeline : IDisposable
                 CreateKvTensor(pastValues, NumTtsLayers, promptLen)),
         };
 
+        cancellationToken.ThrowIfCancellationRequested();
         using var results = _ttsLmPrefill.Run(inputs);
         var resultList = results.ToList();
+        cancellationToken.ThrowIfCancellationRequested();
         var hidden = resultList[0].AsTensor<float>().ToArray();
         var newKeys = resultList[1].AsTensor<float>().ToArray();
         var newValues = resultList[2].AsTensor<float>().ToArray();
@@ -254,8 +297,9 @@ internal sealed class OnnxInferencePipeline : IDisposable
     }
 
     private (float[] hidden, float[] keys, float[] values) RunTtsLmStep(
-        float[] embedVec, int totalLen, float[] pastKeys, float[] pastValues)
+        float[] embedVec, int totalLen, float[] pastKeys, float[] pastValues, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         int pastSeqLen = totalLen - 1;
         var mask = new long[totalLen];
         Array.Fill(mask, 1L);
@@ -277,16 +321,19 @@ internal sealed class OnnxInferencePipeline : IDisposable
                 CreateKvTensorFromFlat(pastValues, NumTtsLayers, pastSeqLen)),
         };
 
+        cancellationToken.ThrowIfCancellationRequested();
         using var results = _ttsLmStep.Run(inputs);
         var resultList = results.ToList();
+        cancellationToken.ThrowIfCancellationRequested();
         var hidden = resultList[0].AsTensor<float>().ToArray();
         var newKeys = resultList[1].AsTensor<float>().ToArray();
         var newValues = resultList[2].AsTensor<float>().ToArray();
         return (hidden, newKeys, newValues);
     }
 
-    private float[] RunDiffusion(float[] posCond, float[] negCond, int frame)
+    private float[] RunDiffusion(float[] posCond, float[] negCond, int frame, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var scheduler = new DiffusionScheduler(DiffusionSteps);
         int[] timesteps = scheduler.GetTimesteps();
 
@@ -296,9 +343,11 @@ internal sealed class OnnxInferencePipeline : IDisposable
 
         for (int i = 0; i < timesteps.Length; i++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             // Run prediction head for both positive and negative conditions
-            float[] condPred = RunPredictionHead(speech, posCond, timesteps[i]);
-            float[] uncondPred = RunPredictionHead(speech, negCond, timesteps[i]);
+            float[] condPred = RunPredictionHead(speech, posCond, timesteps[i], cancellationToken);
+            float[] uncondPred = RunPredictionHead(speech, negCond, timesteps[i], cancellationToken);
 
             // CFG: uncond + scale * (cond - uncond)
             float[] guidedPred = new float[LatentDim];
@@ -311,8 +360,9 @@ internal sealed class OnnxInferencePipeline : IDisposable
         return speech;
     }
 
-    private float[] RunPredictionHead(float[] latent, float[] condition, int timestep)
+    private float[] RunPredictionHead(float[] latent, float[] condition, int timestep, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var inputs = new List<NamedOnnxValue>
         {
             NamedOnnxValue.CreateFromTensor("noisy_latent",
@@ -323,43 +373,50 @@ internal sealed class OnnxInferencePipeline : IDisposable
                 Utils.TensorHelpers.CreateTensor(condition, [1, HiddenSize])),
         };
 
+        cancellationToken.ThrowIfCancellationRequested();
         using var results = _predictionHead.Run(inputs);
         return results.First().AsTensor<float>().ToArray();
     }
 
-    private float[] RunAcousticConnector(float[] latent)
+    private float[] RunAcousticConnector(float[] latent, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var inputs = new List<NamedOnnxValue>
         {
             NamedOnnxValue.CreateFromTensor("speech_latent",
                 Utils.TensorHelpers.CreateTensor(latent, [1, LatentDim])),
         };
 
+        cancellationToken.ThrowIfCancellationRequested();
         using var results = _acousticConnector.Run(inputs);
         return results.First().AsTensor<float>().ToArray();
     }
 
-    private float RunEosClassifier(float[] hiddenState)
+    private float RunEosClassifier(float[] hiddenState, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var inputs = new List<NamedOnnxValue>
         {
             NamedOnnxValue.CreateFromTensor("hidden_state",
                 Utils.TensorHelpers.CreateTensor(hiddenState, [1, HiddenSize])),
         };
 
+        cancellationToken.ThrowIfCancellationRequested();
         using var results = _eosClassifier.Run(inputs);
         float logit = results.First().AsTensor<float>().ToArray()[0];
         return 1.0f / (1.0f + MathF.Exp(-logit)); // sigmoid
     }
 
-    private float[] DecodeLatents(List<float[]> allLatents)
+    private float[] DecodeLatents(List<float[]> allLatents, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         int numFrames = allLatents.Count;
         // Scale latents: (latent - bias) / scaling
         // Layout for decoder: [1, 64, numFrames] (transposed)
         float[] scaled = new float[LatentDim * numFrames];
         for (int f = 0; f < numFrames; f++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             for (int d = 0; d < LatentDim; d++)
             {
                 float val = (allLatents[f][d] - SpeechBiasFactor) / SpeechScalingFactor;
@@ -373,11 +430,16 @@ internal sealed class OnnxInferencePipeline : IDisposable
                 Utils.TensorHelpers.CreateTensor(scaled, [1, LatentDim, numFrames])),
         };
 
+        cancellationToken.ThrowIfCancellationRequested();
         using var results = _acousticDecoder.Run(inputs);
         float[] audio = results.First().AsTensor<float>().ToArray();
 
         for (int i = 0; i < audio.Length; i++)
+        {
             audio[i] = Math.Clamp(audio[i], -1.0f, 1.0f);
+            if ((i & 1023) == 0)
+                cancellationToken.ThrowIfCancellationRequested();
+        }
 
         return audio;
     }

--- a/src/ElBruno.VibeVoiceTTS/VibeVoiceRuntimeDependencies.cs
+++ b/src/ElBruno.VibeVoiceTTS/VibeVoiceRuntimeDependencies.cs
@@ -1,0 +1,27 @@
+using ElBruno.VibeVoiceTTS.Pipeline;
+
+namespace ElBruno.VibeVoiceTTS;
+
+internal sealed class VibeVoiceRuntimeDependencies
+{
+    public static VibeVoiceRuntimeDependencies Default { get; } = new();
+
+    public Func<string, bool> IsModelAvailable { get; init; } = ModelManager.IsModelAvailable;
+
+    public Func<string, string, bool> IsVoiceAvailable { get; init; } = ModelManager.IsVoiceAvailable;
+
+    public Func<string, string, IProgress<DownloadProgress>?, CancellationToken, Task> EnsureModelAvailableAsync { get; init; }
+        = ModelManager.EnsureModelAvailableAsync;
+
+    public Func<string, string, string, IProgress<DownloadProgress>?, CancellationToken, Task> EnsureVoiceAvailableAsync { get; init; }
+        = ModelManager.EnsureVoiceAvailableAsync;
+
+    public Func<string, VibeVoiceOptions, IGenerationPipeline> CreatePipeline { get; init; }
+        = static (modelPath, options) => new OnnxInferencePipeline(
+            modelPath,
+            options.DiffusionSteps,
+            options.CfgScale,
+            options.Seed,
+            options.ExecutionProvider,
+            options.GpuDeviceId);
+}

--- a/src/ElBruno.VibeVoiceTTS/VibeVoiceSynthesizer.cs
+++ b/src/ElBruno.VibeVoiceTTS/VibeVoiceSynthesizer.cs
@@ -9,9 +9,14 @@ namespace ElBruno.VibeVoiceTTS;
 public sealed class VibeVoiceSynthesizer : IVibeVoiceSynthesizer
 {
     private readonly VibeVoiceOptions _options;
+    private readonly VibeVoiceRuntimeDependencies _dependencies;
     private readonly SemaphoreSlim _initLock = new(1, 1);
-    private OnnxInferencePipeline? _pipeline;
+    private readonly SemaphoreSlim _generationLock = new(1, 1);
+    private IGenerationPipeline? _pipeline;
     private bool _disposed;
+
+    /// <inheritdoc/>
+    public event EventHandler<GenerationMetric>? GenerationMetricReported;
 
     /// <summary>
     /// Creates a synthesizer with default options (models stored in shared OS cache).
@@ -21,16 +26,21 @@ public sealed class VibeVoiceSynthesizer : IVibeVoiceSynthesizer
     /// <summary>
     /// Creates a synthesizer with the specified options.
     /// </summary>
-    public VibeVoiceSynthesizer(VibeVoiceOptions options)
+    public VibeVoiceSynthesizer(VibeVoiceOptions options) : this(options, VibeVoiceRuntimeDependencies.Default)
+    {
+    }
+
+    internal VibeVoiceSynthesizer(VibeVoiceOptions options, VibeVoiceRuntimeDependencies dependencies)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
+        _dependencies = dependencies ?? throw new ArgumentNullException(nameof(dependencies));
     }
 
     /// <inheritdoc/>
     public string ModelPath => _options.GetEffectiveModelPath();
 
     /// <inheritdoc/>
-    public bool IsModelAvailable => ModelManager.IsModelAvailable(ModelPath);
+    public bool IsModelAvailable => _dependencies.IsModelAvailable(ModelPath);
 
     /// <inheritdoc/>
     public async Task EnsureModelAvailableAsync(
@@ -50,7 +60,7 @@ public sealed class VibeVoiceSynthesizer : IVibeVoiceSynthesizer
             return;
         }
 
-        await ModelManager.EnsureModelAvailableAsync(
+        await _dependencies.EnsureModelAvailableAsync(
             ModelPath,
             _options.HuggingFaceRepo,
             progress,
@@ -73,28 +83,41 @@ public sealed class VibeVoiceSynthesizer : IVibeVoiceSynthesizer
         string voiceName,
         CancellationToken cancellationToken = default)
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
-        ArgumentException.ThrowIfNullOrWhiteSpace(text);
-        ArgumentException.ThrowIfNullOrWhiteSpace(voiceName);
-        ValidateTextLength(text);
-
-        // Resolve short preset names (e.g. "Carter") to internal names (e.g. "en-Carter_man")
-        var resolvedName = ResolveVoiceName(voiceName);
-
-        // Auto-download voice if not available on disk
-        if (!ModelManager.IsVoiceAvailable(ModelPath, resolvedName))
+        cancellationToken.ThrowIfCancellationRequested();
+        await _generationLock.WaitAsync(cancellationToken);
+        try
         {
-            await ModelManager.EnsureVoiceAvailableAsync(
-                ModelPath, _options.HuggingFaceRepo, resolvedName, null, cancellationToken);
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            ArgumentException.ThrowIfNullOrWhiteSpace(text);
+            ArgumentException.ThrowIfNullOrWhiteSpace(voiceName);
+            ValidateTextLength(text);
+            cancellationToken.ThrowIfCancellationRequested();
 
-            // Reload pipeline to pick up newly downloaded voice
-            await ReloadPipelineAsync();
+            // Resolve short preset names (e.g. "Carter") to internal names (e.g. "en-Carter_man")
+            var resolvedName = ResolveVoiceName(voiceName);
+
+            // Auto-download voice if not available on disk
+            if (!_dependencies.IsVoiceAvailable(ModelPath, resolvedName))
+            {
+                await _dependencies.EnsureVoiceAvailableAsync(
+                    ModelPath, _options.HuggingFaceRepo, resolvedName, null, cancellationToken);
+
+                // Reload pipeline to pick up newly downloaded voice
+                await ReloadPipelineAsync();
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            var pipeline = await GetOrCreatePipelineAsync(cancellationToken);
+
+            // Run inference on a thread pool thread to avoid blocking
+            return await Task.Run(
+                () => pipeline.GenerateAudio(text, resolvedName, cancellationToken, ReportGenerationMetric),
+                cancellationToken);
         }
-
-        var pipeline = await GetOrCreatePipelineAsync();
-
-        // Run inference on a thread pool thread to avoid blocking
-        return await Task.Run(() => pipeline.GenerateAudio(text, resolvedName), cancellationToken);
+        finally
+        {
+            _generationLock.Release();
+        }
     }
 
     /// <inheritdoc/>
@@ -121,7 +144,7 @@ public sealed class VibeVoiceSynthesizer : IVibeVoiceSynthesizer
 
         // No pipeline loaded — check disk for downloaded voices
         return Enum.GetValues<VibeVoicePreset>()
-            .Where(p => ModelManager.IsVoiceAvailable(ModelPath, p.ToVoiceName()))
+            .Where(p => _dependencies.IsVoiceAvailable(ModelPath, p.ToVoiceName()))
             .Select(p => p.ToString())
             .ToArray();
     }
@@ -151,7 +174,7 @@ public sealed class VibeVoiceSynthesizer : IVibeVoiceSynthesizer
 
         // No pipeline loaded — check disk for downloaded voices
         return Enum.GetValues<VibeVoicePreset>()
-            .Where(p => ModelManager.IsVoiceAvailable(ModelPath, p.ToVoiceName()))
+            .Where(p => _dependencies.IsVoiceAvailable(ModelPath, p.ToVoiceName()))
             .Select(p => p.ToVoiceInfo())
             .ToArray();
     }
@@ -176,16 +199,25 @@ public sealed class VibeVoiceSynthesizer : IVibeVoiceSynthesizer
         IProgress<DownloadProgress>? progress = null,
         CancellationToken cancellationToken = default)
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
-        ArgumentException.ThrowIfNullOrWhiteSpace(voiceName);
+        cancellationToken.ThrowIfCancellationRequested();
+        await _generationLock.WaitAsync(cancellationToken);
+        try
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            ArgumentException.ThrowIfNullOrWhiteSpace(voiceName);
 
-        var resolvedName = ResolveVoiceName(voiceName);
+            var resolvedName = ResolveVoiceName(voiceName);
 
-        await ModelManager.EnsureVoiceAvailableAsync(
-            ModelPath, _options.HuggingFaceRepo, resolvedName, progress, cancellationToken);
+            await _dependencies.EnsureVoiceAvailableAsync(
+                ModelPath, _options.HuggingFaceRepo, resolvedName, progress, cancellationToken);
 
-        // Reload pipeline to pick up newly downloaded voice
-        await ReloadPipelineAsync();
+            // Reload pipeline to pick up newly downloaded voice
+            await ReloadPipelineAsync();
+        }
+        finally
+        {
+            _generationLock.Release();
+        }
     }
 
     /// <summary>
@@ -226,12 +258,12 @@ public sealed class VibeVoiceSynthesizer : IVibeVoiceSynthesizer
             throw new ArgumentException($"Invalid voice preset value: {voice}", nameof(voice));
     }
 
-    private async Task<OnnxInferencePipeline> GetOrCreatePipelineAsync()
+    private async Task<IGenerationPipeline> GetOrCreatePipelineAsync(CancellationToken cancellationToken)
     {
         if (_pipeline is not null)
             return _pipeline;
 
-        await _initLock.WaitAsync();
+        await _initLock.WaitAsync(cancellationToken);
         try
         {
             if (_pipeline is not null)
@@ -241,13 +273,7 @@ public sealed class VibeVoiceSynthesizer : IVibeVoiceSynthesizer
                 throw new InvalidOperationException(
                     $"Model files not found at '{ModelPath}'. Call EnsureModelAvailableAsync() first or provide a valid model path.");
 
-            _pipeline = new OnnxInferencePipeline(
-                ModelPath,
-                _options.DiffusionSteps,
-                _options.CfgScale,
-                _options.Seed,
-                _options.ExecutionProvider,
-                _options.GpuDeviceId);
+            _pipeline = _dependencies.CreatePipeline(ModelPath, _options);
 
             return _pipeline;
         }
@@ -278,5 +304,11 @@ public sealed class VibeVoiceSynthesizer : IVibeVoiceSynthesizer
         _disposed = true;
         _pipeline?.Dispose();
         _initLock.Dispose();
+        _generationLock.Dispose();
+    }
+
+    private void ReportGenerationMetric(GenerationMetric metric)
+    {
+        GenerationMetricReported?.Invoke(this, metric);
     }
 }


### PR DESCRIPTION
## Summary
- add cancellable generation checkpoints across the ONNX synthesis pipeline
- serialize per-instance generation and voice reloads so concurrent calls stay safe and cancellable while queued
- emit first-audio and completion timing metrics, add regression tests, and document the runtime behavior

## Validation
- dotnet build src\\ElBruno.VibeVoiceTTS.Tests\\ElBruno.VibeVoiceTTS.Tests.csproj -v minimal
- dotnet test src\\ElBruno.VibeVoiceTTS.Tests\\ElBruno.VibeVoiceTTS.Tests.csproj -v minimal
- dotnet pack src\\ElBruno.VibeVoiceTTS\\ElBruno.VibeVoiceTTS.csproj -c Release -o artifacts -v minimal

Closes #34