### PR TITLE
Add streaming PCM chunk API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A .NET library for text-to-speech synthesis using Microsoft's [VibeVoice-Realtim
 - 🤖 **Pure C# Inference** — ONNX Runtime, zero Python dependency at runtime
 - 🚀 **GPU Acceleration** — DirectML (any Windows GPU) and CUDA (NVIDIA) support with automatic CPU fallback
 - 📥 **Auto-Download** — Models automatically downloaded from 🤗 HuggingFace on first use
+- 📡 **Streaming Chunks API** — ordered PCM chunk delivery through `GenerateAudioStreamingAsync()`
 - 🌍 **6 Voice Presets** — Carter, Davis, Emma, Frank, Grace, Mike (English voices with multilingual experimental support)
 - 💉 **Dependency Injection** — First-class `IServiceCollection` integration
 - 🖥️ **Cross-Platform** — Windows, Linux, macOS, MAUI-ready
@@ -104,6 +105,23 @@ var options = new VibeVoiceOptions
 using var tts = new VibeVoiceSynthesizer(options);
 ```
 
+### 6) Stream ordered PCM chunks
+
+```csharp
+await foreach (var chunk in tts.GenerateAudioStreamingAsync(
+    "Streaming-ready chunk delivery without a second full-audio copy.",
+    VibeVoicePreset.Carter))
+{
+    Console.WriteLine(
+        $"Chunk #{chunk.SequenceNumber} | Samples: {chunk.Samples.Length} | Final: {chunk.IsFinal}");
+}
+
+Console.WriteLine(tts.StreamingCapabilities);
+// -> { SupportsProgressiveGeneration = false, SupportsChunkedDelivery = true }
+```
+
+> **💡 Streaming behavior:** The current ONNX pipeline finishes waveform generation before chunk emission starts, so `SupportsProgressiveGeneration` is `false`. Chunks are then exposed in-order from the generated PCM buffer, so `SupportsChunkedDelivery` is `true`.
+
 | Option | Default | Description |
 |--------|---------|-------------|
 | `ModelPath` | OS cache* | Directory where ONNX models are stored and downloaded |
@@ -118,7 +136,7 @@ using var tts = new VibeVoiceSynthesizer(options);
 
 *\*Default model cache: Windows: `%LOCALAPPDATA%\ElBruno\VibeVoice\models` · Linux/macOS: `~/.local/share/elbruno/vibevoice/models`*
 
-### 6) GPU Acceleration
+### 7) GPU Acceleration
 
 Enable GPU acceleration by setting the execution provider and installing the corresponding NuGet package:
 
@@ -150,7 +168,7 @@ using var tts = new VibeVoiceSynthesizer(options);
 
 > **💡 Note:** If the selected GPU provider is unavailable (missing NuGet package or no compatible GPU), the library automatically falls back to CPU inference. When using DirectML, models with dynamic tensor shapes (LM models, acoustic decoder) run on CPU while fixed-shape models (prediction head, connector, EOS classifier) use GPU — this works around known DirectML limitations with dynamic Reshape and ConvTranspose operations.
 
-### 7) Dependency Injection
+### 8) Dependency Injection
 
 ```csharp
 builder.Services.AddVibeVoice(options =>
@@ -161,7 +179,7 @@ builder.Services.AddVibeVoice(options =>
 // Then inject IVibeVoiceSynthesizer in your services
 ```
 
-### 8) Cancellation, metrics, and concurrent use
+### 9) Cancellation, metrics, streaming, and concurrent use
 
 ```csharp
 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
@@ -180,6 +198,8 @@ float[] audio = await tts.GenerateAudioAsync(
 > **💡 Concurrency behavior:** A single `VibeVoiceSynthesizer` instance serializes `GenerateAudioAsync()` and `EnsureVoiceAvailableAsync()` calls so the shared ONNX pipeline cannot be mutated mid-request. If a caller is waiting for that capacity, cancelling its `CancellationToken` aborts the wait. Create multiple synthesizer instances if you need true parallel generation.
 >
 > **💡 Metrics behavior:** `GenerationMetricReported` emits `FirstAudioReady` when the first latent audio frame is ready and `Completed` when the final waveform has been decoded.
+>
+> **💡 Streaming behavior:** `GenerateAudioStreamingAsync()` uses the same cancellation rules. If cancellation happens while enumerating chunks, no further audio chunks are emitted and exactly one yielded chunk is marked `IsFinal = true`.
 
 > **💡 Tip:** For best results, keep sentences short (~10 words). Longer text may produce artifacts due to model limitations. Consider splitting long text into sentences.
 > **💡 Tip:** The `MaxTextLength` option defaults to 500 characters. Raise it for long passages, or set it to `0` to disable the guard entirely.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,7 +2,19 @@
 
 This guide walks you through setting up and running VibeVoiceTTS.
 
-> **C# library runtime behavior:** Each `VibeVoiceSynthesizer` instance processes one generation request at a time so its shared ONNX pipeline stays consistent. Pass a `CancellationToken` to cancel queued or in-flight generation, and subscribe to `GenerationMetricReported` if you want first-audio and total-duration timings.
+> **C# library runtime behavior:** Each `VibeVoiceSynthesizer` instance processes one generation request at a time so its shared ONNX pipeline stays consistent. Pass a `CancellationToken` to cancel queued or in-flight generation, subscribe to `GenerationMetricReported` if you want first-audio and total-duration timings, and use `GenerateAudioStreamingAsync()` when you want ordered PCM chunks instead of a single `float[]`.
+
+```csharp
+await foreach (var chunk in tts.GenerateAudioStreamingAsync("Hello!", VibeVoicePreset.Carter))
+{
+    Console.WriteLine($"{chunk.SequenceNumber}: {chunk.Samples.Length} samples");
+}
+
+Console.WriteLine(tts.StreamingCapabilities);
+// -> { SupportsProgressiveGeneration = false, SupportsChunkedDelivery = true }
+```
+
+> **Streaming note:** The current ONNX pipeline exposes chunked delivery after waveform generation completes, so streaming is ordered and cancellation-aware but not progressively generated sample-by-sample.
 
 ## Prerequisites
 

--- a/src/ElBruno.VibeVoiceTTS.Tests/VibeVoiceSynthesizerTests.cs
+++ b/src/ElBruno.VibeVoiceTTS.Tests/VibeVoiceSynthesizerTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
 using ElBruno.VibeVoiceTTS.Pipeline;
 using ElBruno.VibeVoiceTTS;
 
@@ -314,6 +315,83 @@ public class VibeVoiceSynthesizerTests
     }
 
     [Fact]
+    public void StreamingCapabilities_ReportChunkedButNotProgressive()
+    {
+        using var tts = new VibeVoiceSynthesizer();
+
+        Assert.False(tts.StreamingCapabilities.SupportsProgressiveGeneration);
+        Assert.True(tts.StreamingCapabilities.SupportsChunkedDelivery);
+    }
+
+    [Fact]
+    public async Task GenerateAudioStreamingAsync_ReturnsOrderedChunksWithoutFullCopy()
+    {
+        float[] audio =
+            Enumerable.Range(0, (VibeVoiceSynthesizer.DefaultStreamingChunkSizeSamples * 2) + 123)
+                .Select(i => i / 100f)
+                .ToArray();
+        using var tts = CreateTestSynthesizer(new BufferedPipeline(audio));
+        var chunks = new List<VibeVoiceAudioChunk>();
+
+        await foreach (var chunk in tts.GenerateAudioStreamingAsync("hello", "Carter"))
+        {
+            chunks.Add(chunk);
+        }
+
+        Assert.Equal(3, chunks.Count);
+        Assert.Equal([0L, 1L, 2L], chunks.Select(chunk => chunk.SequenceNumber).ToArray());
+        Assert.Equal([false, false, true], chunks.Select(chunk => chunk.IsFinal).ToArray());
+        Assert.All(chunks, chunk => Assert.Equal(24_000, chunk.SampleRate));
+
+        float[] rebuilt = chunks.SelectMany(chunk => chunk.Samples.ToArray()).ToArray();
+        Assert.Equal(audio, rebuilt);
+
+        Assert.True(MemoryMarshal.TryGetArray(chunks[0].Samples, out var firstSegment));
+        Assert.True(MemoryMarshal.TryGetArray(chunks[1].Samples, out var secondSegment));
+        Assert.True(MemoryMarshal.TryGetArray(chunks[2].Samples, out var finalSegment));
+        Assert.Same(audio, firstSegment.Array);
+        Assert.Same(audio, secondSegment.Array);
+        Assert.Same(audio, finalSegment.Array);
+    }
+
+    [Fact]
+    public async Task GenerateAudioStreamingAsync_EmptyAudio_EmitsSingleFinalChunk()
+    {
+        using var tts = CreateTestSynthesizer(new BufferedPipeline([]));
+        var chunks = new List<VibeVoiceAudioChunk>();
+
+        await foreach (var chunk in tts.GenerateAudioStreamingAsync("hello", "Carter"))
+        {
+            chunks.Add(chunk);
+        }
+
+        var single = Assert.Single(chunks);
+        Assert.True(single.IsFinal);
+        Assert.Equal(0L, single.SequenceNumber);
+        Assert.True(single.Samples.IsEmpty);
+    }
+
+    [Fact]
+    public async Task GenerateAudioStreamingAsync_CancellationStopsFurtherAudio()
+    {
+        float[] audio =
+            Enumerable.Range(0, VibeVoiceSynthesizer.DefaultStreamingChunkSizeSamples * 2)
+                .Select(i => (float)i)
+                .ToArray();
+        using var tts = CreateTestSynthesizer(new BufferedPipeline(audio));
+        using var cts = new CancellationTokenSource();
+        await using var enumerator = tts.GenerateAudioStreamingAsync("hello", "Carter", cts.Token)
+            .GetAsyncEnumerator();
+
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.False(enumerator.Current.IsFinal);
+
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await enumerator.MoveNextAsync());
+    }
+
+    [Fact]
     public async Task GenerateAudioAsync_StressSwitchesVoicesWithoutCrossRequestLeakage()
     {
         var pipeline = new TrackingPipeline();
@@ -392,6 +470,20 @@ public class VibeVoiceSynthesizerTests
                 FramesGenerated = 2
             });
             return [1f];
+        }
+
+        public string[] GetAvailableVoices() => ["en-Carter_man"];
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class BufferedPipeline(float[] audio) : IGenerationPipeline
+    {
+        public float[] GenerateAudio(string text, string voice, CancellationToken cancellationToken, Action<GenerationMetric>? reportMetric = null)
+        {
+            return audio;
         }
 
         public string[] GetAvailableVoices() => ["en-Carter_man"];

--- a/src/ElBruno.VibeVoiceTTS/ElBruno.VibeVoiceTTS.csproj
+++ b/src/ElBruno.VibeVoiceTTS/ElBruno.VibeVoiceTTS.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>ElBruno.VibeVoiceTTS</PackageId>
-    <Version>0.5.2</Version>
+    <Version>0.6.0</Version>
     <Authors>Bruno Capuano</Authors>
     <Description>A .NET library for VibeVoice text-to-speech using ONNX Runtime. Supports automatic model download from HuggingFace, voice presets, and native C# inference with no Python dependency.</Description>
     <PackageTags>tts;text-to-speech;vibevoice;onnx;onnxruntime;speech;audio;ai;ml</PackageTags>

--- a/src/ElBruno.VibeVoiceTTS/IVibeVoiceSynthesizer.cs
+++ b/src/ElBruno.VibeVoiceTTS/IVibeVoiceSynthesizer.cs
@@ -11,6 +11,11 @@ public interface IVibeVoiceSynthesizer : IDisposable
     event EventHandler<GenerationMetric>? GenerationMetricReported;
 
     /// <summary>
+    /// Gets the streaming behavior supported by this synthesizer implementation.
+    /// </summary>
+    VibeVoiceStreamingCapabilities StreamingCapabilities { get; }
+
+    /// <summary>
     /// Gets whether all required ONNX model files are present at the configured model path.
     /// </summary>
     bool IsModelAvailable { get; }
@@ -44,6 +49,26 @@ public interface IVibeVoiceSynthesizer : IDisposable
     /// If the synthesizer is already busy, waiting for capacity honors the supplied cancellation token.
     /// </summary>
     Task<float[]> GenerateAudioAsync(
+        string text,
+        string voiceName,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Generates ordered PCM chunks using the specified voice preset.
+    /// Current ONNX inference completes waveform generation before chunk emission, so
+    /// SupportsProgressiveGeneration is false while SupportsChunkedDelivery is true.
+    /// </summary>
+    IAsyncEnumerable<VibeVoiceAudioChunk> GenerateAudioStreamingAsync(
+        string text,
+        VibeVoicePreset voice,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Generates ordered PCM chunks using a voice name string.
+    /// Current ONNX inference completes waveform generation before chunk emission, so
+    /// SupportsProgressiveGeneration is false while SupportsChunkedDelivery is true.
+    /// </summary>
+    IAsyncEnumerable<VibeVoiceAudioChunk> GenerateAudioStreamingAsync(
         string text,
         string voiceName,
         CancellationToken cancellationToken = default);

--- a/src/ElBruno.VibeVoiceTTS/VibeVoiceAudioChunk.cs
+++ b/src/ElBruno.VibeVoiceTTS/VibeVoiceAudioChunk.cs
@@ -1,0 +1,10 @@
+namespace ElBruno.VibeVoiceTTS;
+
+/// <summary>
+/// A streamed slice of generated PCM audio.
+/// </summary>
+public sealed record VibeVoiceAudioChunk(
+    ReadOnlyMemory<float> Samples,
+    int SampleRate,
+    long SequenceNumber,
+    bool IsFinal);

--- a/src/ElBruno.VibeVoiceTTS/VibeVoiceStreamingCapabilities.cs
+++ b/src/ElBruno.VibeVoiceTTS/VibeVoiceStreamingCapabilities.cs
@@ -1,0 +1,8 @@
+namespace ElBruno.VibeVoiceTTS;
+
+/// <summary>
+/// Describes how the synthesizer can emit streamed audio updates.
+/// </summary>
+public sealed record VibeVoiceStreamingCapabilities(
+    bool SupportsProgressiveGeneration,
+    bool SupportsChunkedDelivery);

--- a/src/ElBruno.VibeVoiceTTS/VibeVoiceSynthesizer.cs
+++ b/src/ElBruno.VibeVoiceTTS/VibeVoiceSynthesizer.cs
@@ -1,4 +1,5 @@
 using ElBruno.VibeVoiceTTS.Pipeline;
+using System.Runtime.CompilerServices;
 
 namespace ElBruno.VibeVoiceTTS;
 
@@ -8,6 +9,7 @@ namespace ElBruno.VibeVoiceTTS;
 /// </summary>
 public sealed class VibeVoiceSynthesizer : IVibeVoiceSynthesizer
 {
+    internal const int DefaultStreamingChunkSizeSamples = 6_000;
     private readonly VibeVoiceOptions _options;
     private readonly VibeVoiceRuntimeDependencies _dependencies;
     private readonly SemaphoreSlim _initLock = new(1, 1);
@@ -17,6 +19,11 @@ public sealed class VibeVoiceSynthesizer : IVibeVoiceSynthesizer
 
     /// <inheritdoc/>
     public event EventHandler<GenerationMetric>? GenerationMetricReported;
+
+    /// <inheritdoc/>
+    public VibeVoiceStreamingCapabilities StreamingCapabilities { get; } = new(
+        SupportsProgressiveGeneration: false,
+        SupportsChunkedDelivery: true);
 
     /// <summary>
     /// Creates a synthesizer with default options (models stored in shared OS cache).
@@ -117,6 +124,29 @@ public sealed class VibeVoiceSynthesizer : IVibeVoiceSynthesizer
         finally
         {
             _generationLock.Release();
+        }
+    }
+
+    /// <inheritdoc/>
+    public IAsyncEnumerable<VibeVoiceAudioChunk> GenerateAudioStreamingAsync(
+        string text,
+        VibeVoicePreset voice,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateVoicePreset(voice);
+        return GenerateAudioStreamingAsync(text, voice.ToVoiceName(), cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async IAsyncEnumerable<VibeVoiceAudioChunk> GenerateAudioStreamingAsync(
+        string text,
+        string voiceName,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        float[] audio = await GenerateAudioAsync(text, voiceName, cancellationToken).ConfigureAwait(false);
+        foreach (var chunk in CreateStreamingChunks(audio, _options.SampleRate, cancellationToken))
+        {
+            yield return chunk;
         }
     }
 
@@ -256,6 +286,38 @@ public sealed class VibeVoiceSynthesizer : IVibeVoiceSynthesizer
     {
         if (!Enum.IsDefined(typeof(VibeVoicePreset), voice))
             throw new ArgumentException($"Invalid voice preset value: {voice}", nameof(voice));
+    }
+
+    internal static IEnumerable<VibeVoiceAudioChunk> CreateStreamingChunks(
+        float[] audioSamples,
+        int sampleRate,
+        CancellationToken cancellationToken,
+        int chunkSizeSamples = DefaultStreamingChunkSizeSamples)
+    {
+        ArgumentNullException.ThrowIfNull(audioSamples);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(chunkSizeSamples);
+
+        if (audioSamples.Length == 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return new VibeVoiceAudioChunk(ReadOnlyMemory<float>.Empty, sampleRate, 0, true);
+            yield break;
+        }
+
+        long sequenceNumber = 0;
+        for (int offset = 0; offset < audioSamples.Length; offset += chunkSizeSamples)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            int length = Math.Min(chunkSizeSamples, audioSamples.Length - offset);
+            bool isFinal = offset + length >= audioSamples.Length;
+
+            yield return new VibeVoiceAudioChunk(
+                audioSamples.AsMemory(offset, length),
+                sampleRate,
+                sequenceNumber++,
+                isFinal);
+        }
     }
 
     private async Task<IGenerationPipeline> GetOrCreatePipelineAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- add GenerateAudioStreamingAsync() with ordered VibeVoiceAudioChunk slices and streaming capability metadata
- stream from the generated PCM buffer without creating a second full-audio copy
- cover chunk ordering, final-chunk, concatenation, cancellation, and update docs/version to 0.6.0

## Testing
- dotnet test src/ElBruno.VibeVoiceTTS.Tests/ElBruno.VibeVoiceTTS.Tests.csproj --configuration Release --nologo
- dotnet pack src/ElBruno.VibeVoiceTTS/ElBruno.VibeVoiceTTS.csproj --configuration Release --nologo -o artifacts

Closes #33