### PR TITLE
feat: implement Microsoft.Extensions.AI ITextToSpeechClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,46 @@ builder.Services.AddVibeVoice(options =>
 // Then inject IVibeVoiceSynthesizer in your services
 ```
 
-### 9) Cancellation, metrics, streaming, and concurrent use
+### 9) Microsoft.Extensions.AI `ITextToSpeechClient`
+
+```csharp
+using ElBruno.VibeVoiceTTS.Extensions;
+using Microsoft.Extensions.AI;
+
+builder.Services.AddVibeVoice(
+    configure: options =>
+    {
+        options.SampleRate = 24000;
+    },
+    configureTextToSpeech: options =>
+    {
+        options.DefaultAudioFormat = VibeVoiceTextToSpeechOptions.WavMediaType;
+    });
+
+var client = app.Services.GetRequiredService<ITextToSpeechClient>();
+
+TextToSpeechResponse response = await client.GetAudioAsync(
+    "Hello from Microsoft.Extensions.AI!",
+    new TextToSpeechOptions
+    {
+        VoiceId = "Emma",
+        AudioFormat = "audio/pcm;format=s16le"
+    });
+
+var audio = response.Contents.OfType<DataContent>().Single();
+Console.WriteLine(audio.MediaType);
+// -> audio/pcm;rate=24000;channels=1;format=s16le
+```
+
+Supported adapter output types:
+
+- `audio/wav`
+- `audio/pcm;rate=24000;channels=1;format=f32le`
+- `audio/pcm;rate=24000;channels=1;format=s16le`
+
+`GetService(typeof(TextToSpeechClientMetadata))` returns provider metadata, `TextToSpeechOptions.VoiceId` maps to the existing VibeVoice voice presets/internal names, and `AdditionalProperties["sampleRate"]` is validated against the synthesizer's configured sample rate.
+
+### 10) Cancellation, metrics, streaming, and concurrent use
 
 ```csharp
 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));

--- a/src/ElBruno.VibeVoiceTTS.Tests/ElBruno.VibeVoiceTTS.Tests.csproj
+++ b/src/ElBruno.VibeVoiceTTS.Tests/ElBruno.VibeVoiceTTS.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);MEAI001</NoWarn>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -11,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.*" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.20.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />

--- a/src/ElBruno.VibeVoiceTTS.Tests/VibeVoiceTextToSpeechClientTests.cs
+++ b/src/ElBruno.VibeVoiceTTS.Tests/VibeVoiceTextToSpeechClientTests.cs
@@ -1,0 +1,245 @@
+using ElBruno.VibeVoiceTTS.Extensions;
+using ElBruno.VibeVoiceTTS.Pipeline;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace ElBruno.VibeVoiceTTS.Tests;
+
+public class VibeVoiceTextToSpeechClientTests
+{
+    [Fact]
+    public async Task GetAudioAsync_DefaultsToWavAndReturnsResolvedVoiceMetadata()
+    {
+        using var synth = CreateSynthesizer(new[] { 0f, 0.5f, -0.5f });
+        using var client = new VibeVoiceTextToSpeechClient(
+            synth,
+            Options.Create(new VibeVoiceTextToSpeechOptions()));
+
+        TextToSpeechResponse response = await client.GetAudioAsync("hello world");
+
+        Assert.Equal(synth.HuggingFaceRepo, response.ModelId);
+        Assert.NotNull(response.ResponseId);
+
+        var content = Assert.IsType<DataContent>(Assert.Single(response.Contents));
+        Assert.Equal("audio/wav", content.MediaType);
+        Assert.Equal("speech.wav", content.Name);
+        Assert.StartsWith("RIFF", System.Text.Encoding.ASCII.GetString(content.Data.Span[..4]));
+
+        Assert.NotNull(response.AdditionalProperties);
+        Assert.Equal("en-Carter_man", response.AdditionalProperties[VibeVoiceTextToSpeechClient.VoiceIdPropertyName]);
+        Assert.Equal(24_000, response.AdditionalProperties[VibeVoiceTextToSpeechClient.SampleRatePropertyName]);
+    }
+
+    [Theory]
+    [InlineData("s16le", "audio/pcm;rate=24000;channels=1;format=s16le", 4)]
+    [InlineData("audio/pcm;format=f32le", "audio/pcm;rate=24000;channels=1;format=f32le", 8)]
+    public async Task GetAudioAsync_ReturnsCanonicalPcmPayload(string requestedFormat, string expectedMediaType, int expectedLength)
+    {
+        using var synth = CreateSynthesizer(new[] { -1f, 1f });
+        using var client = new VibeVoiceTextToSpeechClient(
+            synth,
+            Options.Create(new VibeVoiceTextToSpeechOptions()));
+
+        TextToSpeechResponse response = await client.GetAudioAsync(
+            "hello world",
+            new TextToSpeechOptions { AudioFormat = requestedFormat, VoiceId = "Emma" });
+
+        var content = Assert.IsType<DataContent>(Assert.Single(response.Contents));
+        Assert.Equal(expectedMediaType, content.MediaType);
+        Assert.Equal(expectedLength, content.Data.Length);
+        Assert.Equal("en-Emma_woman", response.AdditionalProperties![VibeVoiceTextToSpeechClient.VoiceIdPropertyName]);
+    }
+
+    [Fact]
+    public async Task GetAudioAsync_UsesConfiguredMetadataOverride()
+    {
+        using var synth = CreateSynthesizer([0.25f]);
+        using var client = new VibeVoiceTextToSpeechClient(
+            synth,
+            Options.Create(new VibeVoiceTextToSpeechOptions
+            {
+                ProviderName = "custom-vibevoice",
+                DefaultModelId = "custom-model-id"
+            }));
+
+        TextToSpeechClientMetadata metadata = Assert.IsType<TextToSpeechClientMetadata>(
+            client.GetService(typeof(TextToSpeechClientMetadata)));
+        TextToSpeechResponse response = await client.GetAudioAsync("metadata");
+
+        Assert.Equal("custom-vibevoice", metadata.ProviderName);
+        Assert.Equal("custom-model-id", metadata.DefaultModelId);
+        Assert.Equal("custom-model-id", response.ModelId);
+    }
+
+    [Fact]
+    public async Task GetAudioAsync_CancelledWhileWaiting_Throws()
+    {
+        var firstStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirst = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var synth = CreateSynthesizer(new BlockingPipeline(firstStarted, releaseFirst));
+        using var client = new VibeVoiceTextToSpeechClient(
+            synth,
+            Options.Create(new VibeVoiceTextToSpeechOptions()));
+
+        Task<TextToSpeechResponse> first = client.GetAudioAsync("first");
+        await firstStarted.Task;
+
+        using var cts = new CancellationTokenSource();
+        Task<TextToSpeechResponse> second = client.GetAudioAsync("second", cancellationToken: cts.Token);
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => second);
+
+        releaseFirst.SetResult();
+        await first;
+    }
+
+    [Fact]
+    public async Task GetStreamingAudioAsync_ForPcm_ReturnsOrderedUpdates()
+    {
+        float[] audio = Enumerable.Range(0, (VibeVoiceSynthesizer.DefaultStreamingChunkSizeSamples * 2) + 5)
+            .Select(i => i / 100f)
+            .ToArray();
+        using var synth = CreateSynthesizer(new BufferedPipeline(audio));
+        using var client = new VibeVoiceTextToSpeechClient(
+            synth,
+            Options.Create(new VibeVoiceTextToSpeechOptions
+            {
+                DefaultAudioFormat = "audio/pcm;format=s16le"
+            }));
+        var updates = new List<TextToSpeechResponseUpdate>();
+
+        await foreach (TextToSpeechResponseUpdate update in client.GetStreamingAudioAsync("stream"))
+        {
+            updates.Add(update);
+        }
+
+        Assert.Equal(3, updates.Count);
+        Assert.Equal(TextToSpeechResponseUpdateKind.AudioUpdating, updates[0].Kind);
+        Assert.Equal(TextToSpeechResponseUpdateKind.AudioUpdating, updates[1].Kind);
+        Assert.Equal(TextToSpeechResponseUpdateKind.AudioUpdated, updates[2].Kind);
+        Assert.All(updates, update =>
+        {
+            var content = Assert.IsType<DataContent>(Assert.Single(update.Contents));
+            Assert.Equal("audio/pcm;rate=24000;channels=1;format=s16le", content.MediaType);
+        });
+        Assert.Equal(0L, updates[0].AdditionalProperties!["sequenceNumber"]);
+        Assert.Equal(2L, updates[2].AdditionalProperties!["sequenceNumber"]);
+    }
+
+    [Fact]
+    public async Task GetAudioAsync_RejectsMismatchedSampleRateRequest()
+    {
+        using var synth = CreateSynthesizer([0.1f]);
+        using var client = new VibeVoiceTextToSpeechClient(
+            synth,
+            Options.Create(new VibeVoiceTextToSpeechOptions()));
+        var options = new TextToSpeechOptions
+        {
+            AdditionalProperties = new AdditionalPropertiesDictionary
+            {
+                [VibeVoiceTextToSpeechClient.SampleRatePropertyName] = 16_000
+            }
+        };
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(() => client.GetAudioAsync("rate", options));
+
+        Assert.Contains("24000", exception.Message);
+    }
+
+    [Fact]
+    public void GetService_ReturnsWrappedServices()
+    {
+        using var synth = CreateSynthesizer([0.25f]);
+        using var client = new VibeVoiceTextToSpeechClient(
+            synth,
+            Options.Create(new VibeVoiceTextToSpeechOptions()));
+
+        Assert.Same(client, client.GetService(typeof(ITextToSpeechClient)));
+        Assert.Same(synth, client.GetService(typeof(VibeVoiceSynthesizer)));
+        Assert.Same(synth, client.GetService(typeof(IVibeVoiceSynthesizer)));
+        Assert.NotNull(client.GetService(typeof(TextToSpeechClientMetadata)));
+        Assert.Null(client.GetService(typeof(TextToSpeechClientMetadata), serviceKey: "unsupported"));
+    }
+
+    [Fact]
+    public void AddVibeVoice_RegistersITextToSpeechClient()
+    {
+        var services = new ServiceCollection();
+        services.AddVibeVoice(
+            configure: options => options.SampleRate = 16_000,
+            configureTextToSpeech: options =>
+            {
+                options.ProviderName = "test-provider";
+                options.DefaultAudioFormat = "audio/pcm;format=f32le";
+            });
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        var client = Assert.IsType<VibeVoiceTextToSpeechClient>(provider.GetRequiredService<ITextToSpeechClient>());
+        var synth = provider.GetRequiredService<VibeVoiceSynthesizer>();
+        var metadata = Assert.IsType<TextToSpeechClientMetadata>(client.GetService(typeof(TextToSpeechClientMetadata)));
+
+        Assert.Same(synth, client.GetService(typeof(VibeVoiceSynthesizer)));
+        Assert.Equal("test-provider", metadata.ProviderName);
+        Assert.Equal(16_000, synth.SampleRate);
+    }
+
+    private static VibeVoiceSynthesizer CreateSynthesizer(float[] audio, int sampleRate = 24_000)
+    {
+        return CreateSynthesizer(new BufferedPipeline(audio), sampleRate);
+    }
+
+    private static VibeVoiceSynthesizer CreateSynthesizer(IGenerationPipeline pipeline, int sampleRate = 24_000)
+    {
+        return new VibeVoiceSynthesizer(
+            new VibeVoiceOptions
+            {
+                ModelPath = VibeVoiceOptions.GetDefaultModelPath(),
+                SampleRate = sampleRate
+            },
+            new VibeVoiceRuntimeDependencies
+            {
+                IsModelAvailable = static _ => true,
+                IsVoiceAvailable = static (_, _) => true,
+                EnsureModelAvailableAsync = static (_, _, _, _) => Task.CompletedTask,
+                EnsureVoiceAvailableAsync = static (_, _, _, _, _) => Task.CompletedTask,
+                CreatePipeline = (_, _) => pipeline
+            });
+    }
+
+    private sealed class BufferedPipeline(float[] audio) : IGenerationPipeline
+    {
+        public float[] GenerateAudio(string text, string voice, CancellationToken cancellationToken, Action<GenerationMetric>? reportMetric = null)
+            => audio;
+
+        public string[] GetAvailableVoices() => ["en-Carter_man", "en-Emma_woman"];
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class BlockingPipeline(TaskCompletionSource firstStarted, TaskCompletionSource releaseFirst) : IGenerationPipeline
+    {
+        private int _callCount;
+
+        public float[] GenerateAudio(string text, string voice, CancellationToken cancellationToken, Action<GenerationMetric>? reportMetric = null)
+        {
+            if (Interlocked.Increment(ref _callCount) == 1)
+            {
+                firstStarted.SetResult();
+                releaseFirst.Task.GetAwaiter().GetResult();
+            }
+
+            return [1f];
+        }
+
+        public string[] GetAvailableVoices() => ["en-Carter_man", "en-Emma_woman"];
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/ElBruno.VibeVoiceTTS/ElBruno.VibeVoiceTTS.csproj
+++ b/src/ElBruno.VibeVoiceTTS/ElBruno.VibeVoiceTTS.csproj
@@ -5,13 +5,16 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>ElBruno.VibeVoiceTTS</RootNamespace>
+    <NoWarn>$(NoWarn);MEAI001</NoWarn>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 
     <!-- NuGet Package Metadata -->
     <PackageId>ElBruno.VibeVoiceTTS</PackageId>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <Authors>Bruno Capuano</Authors>
     <Description>A .NET library for VibeVoice text-to-speech using ONNX Runtime. Supports automatic model download from HuggingFace, voice presets, and native C# inference with no Python dependency.</Description>
-    <PackageTags>tts;text-to-speech;vibevoice;onnx;onnxruntime;speech;audio;ai;ml</PackageTags>
+    <PackageTags>tts;text-to-speech;vibevoice;onnx;onnxruntime;speech;audio;ai;ml;microsoft-extensions-ai</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/elbruno/ElBruno.VibeVoiceTTS</PackageProjectUrl>
     <RepositoryUrl>https://github.com/elbruno/ElBruno.VibeVoiceTTS</RepositoryUrl>
@@ -28,7 +31,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.20.*" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.7.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.*" />
     <PackageReference Include="ElBruno.HuggingFace.Downloader" Version="0.5.0" />
   </ItemGroup>
 

--- a/src/ElBruno.VibeVoiceTTS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ElBruno.VibeVoiceTTS/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Options;
 
 namespace ElBruno.VibeVoiceTTS.Extensions;
 
@@ -12,20 +14,31 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <param name="configure">Optional action to configure <see cref="VibeVoiceOptions"/>.</param>
+    /// <param name="configureTextToSpeech">Optional action to configure <see cref="VibeVoiceTextToSpeechOptions"/>.</param>
     /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddVibeVoice(
         this IServiceCollection services,
-        Action<VibeVoiceOptions>? configure = null)
+        Action<VibeVoiceOptions>? configure = null,
+        Action<VibeVoiceTextToSpeechOptions>? configureTextToSpeech = null)
     {
         var options = new VibeVoiceOptions();
         configure?.Invoke(options);
 
         services.AddSingleton(options);
-        services.AddSingleton<IVibeVoiceSynthesizer>(sp =>
+        services.AddOptions<VibeVoiceTextToSpeechOptions>();
+        if (configureTextToSpeech is not null)
+        {
+            services.Configure(configureTextToSpeech);
+        }
+
+        services.AddSingleton<VibeVoiceSynthesizer>(sp =>
         {
             var opts = sp.GetRequiredService<VibeVoiceOptions>();
             return new VibeVoiceSynthesizer(opts);
         });
+        services.AddSingleton<IVibeVoiceSynthesizer>(sp => sp.GetRequiredService<VibeVoiceSynthesizer>());
+        services.AddSingleton<VibeVoiceTextToSpeechClient>();
+        services.AddSingleton<ITextToSpeechClient>(sp => sp.GetRequiredService<VibeVoiceTextToSpeechClient>());
 
         return services;
     }

--- a/src/ElBruno.VibeVoiceTTS/IVibeVoiceSynthesizer.cs
+++ b/src/ElBruno.VibeVoiceTTS/IVibeVoiceSynthesizer.cs
@@ -26,6 +26,16 @@ public interface IVibeVoiceSynthesizer : IDisposable
     string ModelPath { get; }
 
     /// <summary>
+    /// Gets the configured audio sample rate in Hz.
+    /// </summary>
+    int SampleRate { get; }
+
+    /// <summary>
+    /// Gets the HuggingFace repository used to resolve model assets.
+    /// </summary>
+    string HuggingFaceRepo { get; }
+
+    /// <summary>
     /// Ensures model files are available, downloading from HuggingFace if needed.
     /// </summary>
     Task EnsureModelAvailableAsync(

--- a/src/ElBruno.VibeVoiceTTS/Utils/AudioWriter.cs
+++ b/src/ElBruno.VibeVoiceTTS/Utils/AudioWriter.cs
@@ -1,3 +1,5 @@
+using System.Buffers.Binary;
+
 namespace ElBruno.VibeVoiceTTS.Utils;
 
 /// <summary>
@@ -15,16 +17,24 @@ public static class AudioWriter
         if (samples.Length == 0)
             throw new ArgumentException("Audio samples array is empty.", nameof(samples));
 
+        var dir = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+
+        File.WriteAllBytes(path, GetWavBytes(samples, sampleRate, channels));
+    }
+
+    /// <summary>
+    /// Serializes float audio samples into a 16-bit PCM WAV payload.
+    /// </summary>
+    public static byte[] GetWavBytes(ReadOnlyMemory<float> samples, int sampleRate = 24000, int channels = 1)
+    {
         const int bitsPerSample = 16;
         int byteRate = sampleRate * channels * bitsPerSample / 8;
         int blockAlign = channels * bitsPerSample / 8;
         int dataSize = samples.Length * blockAlign;
 
-        var dir = Path.GetDirectoryName(path);
-        if (!string.IsNullOrEmpty(dir))
-            Directory.CreateDirectory(dir);
-
-        using var stream = new FileStream(path, FileMode.Create, FileAccess.Write);
+        using var stream = new MemoryStream(44 + dataSize);
         using var writer = new BinaryWriter(stream);
 
         writer.Write("RIFF"u8);
@@ -43,11 +53,57 @@ public static class AudioWriter
         writer.Write("data"u8);
         writer.Write(dataSize);
 
-        for (int i = 0; i < samples.Length; i++)
+        ReadOnlySpan<float> sampleSpan = samples.Span;
+        for (int i = 0; i < sampleSpan.Length; i++)
         {
-            float clamped = Math.Clamp(samples[i], -1.0f, 1.0f);
-            short pcmSample = (short)Math.Round(clamped * short.MaxValue);
-            writer.Write(pcmSample);
+            writer.Write(ToPcm16(sampleSpan[i]));
         }
+
+        return stream.ToArray();
+    }
+
+    /// <summary>
+    /// Serializes float audio samples into signed 16-bit PCM little-endian bytes.
+    /// </summary>
+    public static byte[] GetPcm16LeBytes(ReadOnlyMemory<float> samples)
+    {
+        byte[] bytes = new byte[samples.Length * sizeof(short)];
+        Span<byte> destination = bytes.AsSpan();
+        int offset = 0;
+
+        ReadOnlySpan<float> sampleSpan = samples.Span;
+        for (int i = 0; i < sampleSpan.Length; i++)
+        {
+            short pcmSample = ToPcm16(sampleSpan[i]);
+            BinaryPrimitives.WriteInt16LittleEndian(destination.Slice(offset, sizeof(short)), pcmSample);
+            offset += sizeof(short);
+        }
+
+        return bytes;
+    }
+
+    /// <summary>
+    /// Serializes float audio samples into IEEE 754 single-precision PCM little-endian bytes.
+    /// </summary>
+    public static byte[] GetPcmFloat32LeBytes(ReadOnlyMemory<float> samples)
+    {
+        byte[] bytes = new byte[samples.Length * sizeof(float)];
+        Span<byte> destination = bytes.AsSpan();
+        ReadOnlySpan<float> source = samples.Span;
+
+        for (int i = 0; i < source.Length; i++)
+        {
+            BinaryPrimitives.WriteSingleLittleEndian(
+                destination.Slice(i * sizeof(float), sizeof(float)),
+                source[i]);
+        }
+
+        return bytes;
+    }
+
+    private static short ToPcm16(float sample)
+    {
+        float clamped = Math.Clamp(sample, -1.0f, 1.0f);
+        return (short)Math.Round(clamped * short.MaxValue);
     }
 }

--- a/src/ElBruno.VibeVoiceTTS/VibeVoiceSynthesizer.cs
+++ b/src/ElBruno.VibeVoiceTTS/VibeVoiceSynthesizer.cs
@@ -50,6 +50,12 @@ public sealed class VibeVoiceSynthesizer : IVibeVoiceSynthesizer
     public bool IsModelAvailable => _dependencies.IsModelAvailable(ModelPath);
 
     /// <inheritdoc/>
+    public int SampleRate => _options.SampleRate;
+
+    /// <inheritdoc/>
+    public string HuggingFaceRepo => _options.HuggingFaceRepo;
+
+    /// <inheritdoc/>
     public async Task EnsureModelAvailableAsync(
         IProgress<DownloadProgress>? progress = null,
         CancellationToken cancellationToken = default)

--- a/src/ElBruno.VibeVoiceTTS/VibeVoiceTextToSpeechClient.cs
+++ b/src/ElBruno.VibeVoiceTTS/VibeVoiceTextToSpeechClient.cs
@@ -1,0 +1,361 @@
+using System.Runtime.CompilerServices;
+using ElBruno.VibeVoiceTTS.Utils;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Options;
+
+namespace ElBruno.VibeVoiceTTS;
+
+/// <summary>
+/// Microsoft.Extensions.AI adapter over <see cref="VibeVoiceSynthesizer"/>.
+/// </summary>
+public sealed class VibeVoiceTextToSpeechClient : ITextToSpeechClient
+{
+    internal const string AudioFormatPropertyName = "audioFormat";
+    internal const string SampleRatePropertyName = "sampleRate";
+    internal const string VoiceIdPropertyName = "voiceId";
+
+    private readonly VibeVoiceSynthesizer _synthesizer;
+    private readonly IOptions<VibeVoiceTextToSpeechOptions> _optionsAccessor;
+    private readonly TextToSpeechClientMetadata _metadata;
+    private bool _disposed;
+
+    /// <summary>
+    /// Creates a new adapter over an existing <see cref="VibeVoiceSynthesizer"/>.
+    /// </summary>
+    public VibeVoiceTextToSpeechClient(
+        VibeVoiceSynthesizer synthesizer,
+        IOptions<VibeVoiceTextToSpeechOptions> options)
+    {
+        _synthesizer = synthesizer ?? throw new ArgumentNullException(nameof(synthesizer));
+        _optionsAccessor = options ?? throw new ArgumentNullException(nameof(options));
+
+        VibeVoiceTextToSpeechOptions configured = options.Value
+            ?? throw new InvalidOperationException("VibeVoiceTextToSpeechOptions must be configured.");
+        _metadata = new(
+            configured.ProviderName,
+            configured.ProviderUri,
+            configured.DefaultModelId ?? synthesizer.HuggingFaceRepo);
+    }
+
+    /// <inheritdoc />
+    public object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        ArgumentNullException.ThrowIfNull(serviceType);
+
+        return
+            serviceKey is not null ? null :
+            serviceType == typeof(TextToSpeechClientMetadata) ? _metadata :
+            serviceType == typeof(VibeVoiceSynthesizer) ? _synthesizer :
+            serviceType == typeof(IVibeVoiceSynthesizer) ? _synthesizer :
+            serviceType == typeof(VibeVoiceTextToSpeechOptions) ? _optionsAccessor.Value :
+            serviceType == typeof(IOptions<VibeVoiceTextToSpeechOptions>) ? _optionsAccessor :
+            serviceType.IsInstanceOfType(this) ? this :
+            null;
+    }
+
+    /// <inheritdoc />
+    public Task<TextToSpeechResponse> GetAudioAsync(
+        string text,
+        TextToSpeechOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(text);
+
+        ResolvedRequest request = ResolveRequest(options);
+        return GenerateResponseAsync(text, request, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<TextToSpeechResponseUpdate> GetStreamingAudioAsync(
+        string text,
+        TextToSpeechOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(text);
+
+        ResolvedRequest request = ResolveRequest(options);
+        if (!request.Format.SupportsChunkStreaming)
+        {
+            foreach (TextToSpeechResponseUpdate update in
+                (await GenerateResponseAsync(text, request, cancellationToken).ConfigureAwait(false)).ToTextToSpeechResponseUpdates())
+            {
+                yield return update;
+            }
+
+            yield break;
+        }
+
+        await foreach (VibeVoiceAudioChunk chunk in _synthesizer
+            .GenerateAudioStreamingAsync(text, request.VoiceId, cancellationToken)
+            .WithCancellation(cancellationToken)
+            .ConfigureAwait(false))
+        {
+            yield return new TextToSpeechResponseUpdate(
+                [CreateDataContent(chunk.Samples, request.Format, chunk.SampleRate)])
+            {
+                Kind = chunk.IsFinal
+                    ? TextToSpeechResponseUpdateKind.AudioUpdated
+                    : TextToSpeechResponseUpdateKind.AudioUpdating,
+                ModelId = request.ModelId,
+                ResponseId = request.ResponseId,
+                AdditionalProperties = CreateAdditionalProperties(
+                    request,
+                    chunk.SampleRate,
+                    chunk.SequenceNumber,
+                    chunk.IsFinal),
+                RawRepresentation = chunk
+            };
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _disposed = true;
+    }
+
+    private async Task<TextToSpeechResponse> GenerateResponseAsync(
+        string text,
+        ResolvedRequest request,
+        CancellationToken cancellationToken)
+    {
+        float[] audio = await _synthesizer
+            .GenerateAudioAsync(text, request.VoiceId, cancellationToken)
+            .ConfigureAwait(false);
+        var content = CreateDataContent(audio, request.Format, _synthesizer.SampleRate);
+
+        return new TextToSpeechResponse([content])
+        {
+            ModelId = request.ModelId,
+            ResponseId = request.ResponseId,
+            AdditionalProperties = CreateAdditionalProperties(
+                request,
+                _synthesizer.SampleRate,
+                sequenceNumber: null,
+                isFinal: true),
+            RawRepresentation = audio
+        };
+    }
+
+    private ResolvedRequest ResolveRequest(TextToSpeechOptions? options)
+    {
+        VibeVoiceTextToSpeechOptions configured = _optionsAccessor.Value;
+        int sampleRate = ResolveSampleRate(options?.AdditionalProperties, _synthesizer.SampleRate);
+        string voiceId = string.IsNullOrWhiteSpace(options?.VoiceId)
+            ? configured.DefaultVoiceId
+            : options!.VoiceId!;
+        string resolvedVoiceId = VibeVoiceSynthesizer.ResolveVoiceName(voiceId);
+        ResolvedAudioFormat format = ResolveAudioFormat(options?.AudioFormat ?? configured.DefaultAudioFormat, sampleRate);
+        string responseId = $"vibevoice-{Guid.NewGuid():N}";
+
+        return new ResolvedRequest(
+            resolvedVoiceId,
+            options?.ModelId ?? _metadata.DefaultModelId,
+            format,
+            responseId,
+            options?.AdditionalProperties?.Clone());
+    }
+
+    private static int ResolveSampleRate(AdditionalPropertiesDictionary? properties, int defaultSampleRate)
+    {
+        if (properties is null || !properties.TryGetValue(SampleRatePropertyName, out object? value) || value is null)
+        {
+            return defaultSampleRate;
+        }
+
+        int requestedSampleRate = value switch
+        {
+            int intValue => intValue,
+            long longValue when longValue is >= int.MinValue and <= int.MaxValue => (int)longValue,
+            short shortValue => shortValue,
+            byte byteValue => byteValue,
+            string text when int.TryParse(text, out int parsed) => parsed,
+            _ => throw new ArgumentException(
+                $"AdditionalProperties['{SampleRatePropertyName}'] must be an integer value.",
+                nameof(properties))
+        };
+
+        if (requestedSampleRate != defaultSampleRate)
+        {
+            throw new NotSupportedException(
+                $"The configured synthesizer sample rate is {defaultSampleRate} Hz, but {requestedSampleRate} Hz was requested. " +
+                "Configure VibeVoiceOptions.SampleRate on the synthesizer to change the output rate.");
+        }
+
+        return requestedSampleRate;
+    }
+
+    private static ResolvedAudioFormat ResolveAudioFormat(string? requestedFormat, int sampleRate)
+    {
+        string format = string.IsNullOrWhiteSpace(requestedFormat)
+            ? VibeVoiceTextToSpeechOptions.WavMediaType
+            : requestedFormat.Trim();
+
+        if (format.Equals("wav", StringComparison.OrdinalIgnoreCase)
+            || format.Equals(VibeVoiceTextToSpeechOptions.WavMediaType, StringComparison.OrdinalIgnoreCase))
+        {
+            return new ResolvedAudioFormat(
+                AudioOutputKind.Wav,
+                VibeVoiceTextToSpeechOptions.WavMediaType,
+                "speech.wav",
+                false);
+        }
+
+        if (TryResolvePcmFormat(format, sampleRate, out ResolvedAudioFormat resolved))
+        {
+            return resolved;
+        }
+
+        throw new NotSupportedException(
+            $"Unsupported audio format '{requestedFormat}'. Supported formats are '{VibeVoiceTextToSpeechOptions.WavMediaType}', " +
+            $"'audio/pcm;rate={sampleRate};channels=1;format=f32le', and 'audio/pcm;rate={sampleRate};channels=1;format=s16le'.");
+    }
+
+    private static bool TryResolvePcmFormat(string requestedFormat, int sampleRate, out ResolvedAudioFormat resolved)
+    {
+        resolved = default;
+
+        if (requestedFormat.Equals("f32le", StringComparison.OrdinalIgnoreCase)
+            || requestedFormat.Equals("pcm-f32le", StringComparison.OrdinalIgnoreCase))
+        {
+            resolved = CreatePcmFormat(AudioOutputKind.PcmFloat32, sampleRate);
+            return true;
+        }
+
+        if (requestedFormat.Equals("s16le", StringComparison.OrdinalIgnoreCase)
+            || requestedFormat.Equals("pcm-s16le", StringComparison.OrdinalIgnoreCase))
+        {
+            resolved = CreatePcmFormat(AudioOutputKind.PcmInt16, sampleRate);
+            return true;
+        }
+
+        if (!requestedFormat.StartsWith("audio/pcm", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var parameters = requestedFormat.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Skip(1)
+            .Select(parameter => parameter.Split('=', 2, StringSplitOptions.TrimEntries))
+            .Where(parts => parts.Length == 2)
+            .ToDictionary(parts => parts[0], parts => parts[1], StringComparer.OrdinalIgnoreCase);
+
+        if (parameters.TryGetValue("rate", out string? rateText)
+            && (!int.TryParse(rateText, out int rate) || rate != sampleRate))
+        {
+            throw new NotSupportedException(
+                $"Requested PCM rate '{rateText}' is not supported. Configure the synthesizer for {sampleRate} Hz or request that exact rate.");
+        }
+
+        if (parameters.TryGetValue("channels", out string? channelsText)
+            && (!int.TryParse(channelsText, out int channels) || channels != 1))
+        {
+            throw new NotSupportedException("Only mono PCM output (channels=1) is supported.");
+        }
+
+        if (!parameters.TryGetValue("format", out string? format))
+        {
+            throw new NotSupportedException("PCM output requires a 'format' parameter of either 'f32le' or 's16le'.");
+        }
+
+        if (format.Equals("f32le", StringComparison.OrdinalIgnoreCase))
+        {
+            resolved = CreatePcmFormat(AudioOutputKind.PcmFloat32, sampleRate);
+            return true;
+        }
+
+        if (format.Equals("s16le", StringComparison.OrdinalIgnoreCase))
+        {
+            resolved = CreatePcmFormat(AudioOutputKind.PcmInt16, sampleRate);
+            return true;
+        }
+
+        throw new NotSupportedException(
+            $"PCM format '{format}' is not supported. Use 'f32le' or 's16le'.");
+    }
+
+    private static ResolvedAudioFormat CreatePcmFormat(AudioOutputKind kind, int sampleRate)
+    {
+        return kind switch
+        {
+            AudioOutputKind.PcmFloat32 => new ResolvedAudioFormat(
+                kind,
+                string.Format(
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    VibeVoiceTextToSpeechOptions.PcmFloat32MediaTypeTemplate,
+                    sampleRate),
+                "speech-f32le.pcm",
+                true),
+            AudioOutputKind.PcmInt16 => new ResolvedAudioFormat(
+                kind,
+                string.Format(
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    VibeVoiceTextToSpeechOptions.PcmInt16MediaTypeTemplate,
+                    sampleRate),
+                "speech-s16le.pcm",
+                true),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null)
+        };
+    }
+
+    private static DataContent CreateDataContent(
+        ReadOnlyMemory<float> audio,
+        ResolvedAudioFormat format,
+        int sampleRate)
+    {
+        byte[] bytes = format.Kind switch
+        {
+            AudioOutputKind.Wav => AudioWriter.GetWavBytes(audio, sampleRate),
+            AudioOutputKind.PcmFloat32 => AudioWriter.GetPcmFloat32LeBytes(audio),
+            AudioOutputKind.PcmInt16 => AudioWriter.GetPcm16LeBytes(audio),
+            _ => throw new ArgumentOutOfRangeException(nameof(format))
+        };
+
+        return new DataContent(bytes, format.MediaType)
+        {
+            Name = format.FileName
+        };
+    }
+
+    private static AdditionalPropertiesDictionary CreateAdditionalProperties(
+        ResolvedRequest request,
+        int sampleRate,
+        long? sequenceNumber,
+        bool isFinal)
+    {
+        AdditionalPropertiesDictionary properties = request.AdditionalProperties?.Clone() ?? new AdditionalPropertiesDictionary();
+        properties[AudioFormatPropertyName] = request.Format.MediaType;
+        properties[SampleRatePropertyName] = sampleRate;
+        properties[VoiceIdPropertyName] = request.VoiceId;
+        properties["isFinal"] = isFinal;
+
+        if (sequenceNumber is not null)
+        {
+            properties["sequenceNumber"] = sequenceNumber.Value;
+        }
+
+        return properties;
+    }
+
+    private enum AudioOutputKind
+    {
+        Wav,
+        PcmFloat32,
+        PcmInt16
+    }
+
+    private readonly record struct ResolvedAudioFormat(
+        AudioOutputKind Kind,
+        string MediaType,
+        string FileName,
+        bool SupportsChunkStreaming);
+
+    private readonly record struct ResolvedRequest(
+        string VoiceId,
+        string? ModelId,
+        ResolvedAudioFormat Format,
+        string ResponseId,
+        AdditionalPropertiesDictionary? AdditionalProperties);
+}

--- a/src/ElBruno.VibeVoiceTTS/VibeVoiceTextToSpeechOptions.cs
+++ b/src/ElBruno.VibeVoiceTTS/VibeVoiceTextToSpeechOptions.cs
@@ -1,0 +1,48 @@
+namespace ElBruno.VibeVoiceTTS;
+
+/// <summary>
+/// Configuration for the Microsoft.Extensions.AI text-to-speech adapter.
+/// </summary>
+public sealed class VibeVoiceTextToSpeechOptions
+{
+    /// <summary>
+    /// Canonical WAV media type.
+    /// </summary>
+    public const string WavMediaType = "audio/wav";
+
+    /// <summary>
+    /// Canonical PCM float media type template.
+    /// </summary>
+    public const string PcmFloat32MediaTypeTemplate = "audio/pcm;rate={0};channels=1;format=f32le";
+
+    /// <summary>
+    /// Canonical PCM 16-bit integer media type template.
+    /// </summary>
+    public const string PcmInt16MediaTypeTemplate = "audio/pcm;rate={0};channels=1;format=s16le";
+
+    /// <summary>
+    /// Default voice ID used when the request does not provide one.
+    /// </summary>
+    public string DefaultVoiceId { get; set; } = nameof(VibeVoicePreset.Carter);
+
+    /// <summary>
+    /// Default audio format returned by the adapter.
+    /// </summary>
+    public string DefaultAudioFormat { get; set; } = WavMediaType;
+
+    /// <summary>
+    /// Provider name exposed through <see cref="Microsoft.Extensions.AI.TextToSpeechClientMetadata"/>.
+    /// </summary>
+    public string ProviderName { get; set; } = "vibevoice";
+
+    /// <summary>
+    /// Provider URI exposed through <see cref="Microsoft.Extensions.AI.TextToSpeechClientMetadata"/>.
+    /// </summary>
+    public Uri ProviderUri { get; set; } = new("https://huggingface.co/elbruno/VibeVoice-Realtime-0.5B-ONNX");
+
+    /// <summary>
+    /// Default model ID exposed through <see cref="Microsoft.Extensions.AI.TextToSpeechClientMetadata"/>.
+    /// If null, the adapter falls back to the synthesizer's configured HuggingFace repository.
+    /// </summary>
+    public string? DefaultModelId { get; set; }
+}


### PR DESCRIPTION
## Summary
- add a Microsoft.Extensions.AI ITextToSpeechClient adapter over VibeVoiceSynthesizer
- register the adapter through AddVibeVoice(...), expose metadata, and support WAV / PCM outputs in-memory
- add focused adapter tests and README documentation for the new integration

## Validation
- dotnet build src/ElBruno.VibeVoiceTTS/ElBruno.VibeVoiceTTS.csproj
- dotnet test src/ElBruno.VibeVoiceTTS.Tests/ElBruno.VibeVoiceTTS.Tests.csproj
- dotnet pack src/ElBruno.VibeVoiceTTS/ElBruno.VibeVoiceTTS.csproj -c Debug --no-build -o <session artifacts>

Closes #32